### PR TITLE
An example showing how to set PHP-namespace in PHP-CPP

### DIFF
--- a/Examples/Namespaces/README.md
+++ b/Examples/Namespaces/README.md
@@ -1,0 +1,61 @@
+The namespace in PHP is not defined no internal structure.
+It is only a part of the name defined in it a class or function.
+When we write
+```php
+<?php namespace TestNamespace;
+class Foo {}
+?>
+```
+the parser simply appends 'TestNamespace\' as a prefix to the name of the Foo class.
+This is evident if you look in the interior of the Zend Engine.
+The only place, where we are confronted with the namespace in the Zend Engine -- this structure `struct _zend_compiler_globals {}` в /path/to/php-src/Zend/zend_globals.h
+Mention namespace also occurs in /path/to/php-src/Zend/zend_compile.h in functions such as
+int zend_do_begin_function_call(znode *function_name, zend_bool check_namespace TSRMLS_DC);
+That just confirms what was said.
+This may not be obvious, if not to look at the insides of Zend.
+
+So the following code in PHP
+```php
+<?php
+class TestNamespace\Foo {}
+?>
+```
+will cause error analyzer `Parse error: syntax error, unexpected '\' `
+When we coding extension for PHP in C or C++, we no need to inform the parser.
+We can just append the prefix `TestNamespace\` to a names of defined classes or functions, and it will work.
+
+example:
+PHP-CPP:
+```c
+        ...
+        extension.add(
+            "NamespaceExample\\TestClass", 
+            Php::Class<MyTestClass>({
+                Php::Public("myMethod", Php::Method<MyTestClass>(&MyTestClass::myMethod)),
+            })
+        );
+
+        extension.add("NamespaceExample\\TestFunc", MyTestFunc);
+        ...
+```
+PHP:
+```php
+<?php namespace NamespaceExample;
+var_dump(new TestClass());
+
+echo TestFunc();
+
+$refl = new \ReflectionClass('NamespaceExample\TestClass');
+echo "\nNamespaceName: ", $refl->getNamespaceName();
+
+echo "\nTestClass inNamespace: " ;
+var_export($refl->inNamespace());
+```
+output:
+```
+object(NamespaceExample\TestClass)#1 (0) {
+}
+I'm is TestFunc
+NamespaceName: NamespaceExample
+TestClass inNamespace: true
+```

--- a/Examples/Namespaces/cpp/Makefile
+++ b/Examples/Namespaces/cpp/Makefile
@@ -1,0 +1,32 @@
+CPP             = g++
+RM              = rm -f
+CPP_FLAGS       = -Wall -c -I. -O2 -std=c++11
+
+PREFIX			= /usr
+#Edit these lines to correspond with your own directories
+LIBRARY_DIR		= ${PREFIX}/lib/php5/20121212
+PHP_CONFIG_DIR	= /etc/php5/cli/conf.d
+
+LD              = g++
+LD_FLAGS        = -Wall -shared -O2 
+RESULT          = mytestext.so
+
+PHPINIFILE		= mytestext.ini
+
+SOURCES			= $(wildcard *.cpp)
+OBJECTS         = $(SOURCES:%.cpp=%.o)
+
+all:	${OBJECTS} ${RESULT}
+
+${RESULT}: ${OBJECTS}
+		${LD} ${LD_FLAGS} -o $@ ${OBJECTS} -lphpcpp
+
+clean:
+		${RM} *.obj *~* ${OBJECTS} ${RESULT}
+
+${OBJECTS}: 
+		${CPP} ${CPP_FLAGS} -fpic -o $@ ${@:%.o=%.cpp}
+
+install:
+		cp -f ${RESULT} ${LIBRARY_DIR}
+		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}

--- a/Examples/Namespaces/cpp/mytestext.cpp
+++ b/Examples/Namespaces/cpp/mytestext.cpp
@@ -1,0 +1,59 @@
+/**
+ *  mytestext.cpp
+ * 
+ *  An example showing how to set PHP-namespace in PHP-CPP
+ *  see README.md
+ */
+
+#include <phpcpp.h>
+
+/**
+ * class NamespaceExample\TestClass
+ */
+class MyTestClass : public Php::Base
+{
+public:
+    MyTestClass() {}
+    virtual ~MyTestClass() {}
+    virtual void __construct() {}
+    virtual void __destruct() {}
+
+    void myMethod() {}
+};
+
+
+/**
+ * function NamespaceExample\TestFunc
+ * @param void
+ * @return string
+ */
+Php::Value MyTestFunc() {
+    return "I'm is TestFunc";
+}
+
+
+// Symbols are exported according to the "C" language
+extern "C" 
+{
+    // export the "get_module" function that will be called by the Zend engine
+    PHPCPP_EXPORT void *get_module()
+    {
+        // create extension
+        static Php::Extension extension("NamespaceExampleExt","0.1");
+        
+        // add the custom class ot the extension
+        extension.add(
+            // set PHP-namespace `NamespaceExample`
+            "NamespaceExample\\TestClass", 
+            Php::Class<MyTestClass>({
+                Php::Public("myMethod", Php::Method<MyTestClass>(&MyTestClass::myMethod)),
+            })
+        );
+
+        // set PHP-namespace `NamespaceExample`
+        extension.add("NamespaceExample\\TestFunc", MyTestFunc);
+                
+        // return the extension module
+        return extension.module();
+    }
+}

--- a/Examples/Namespaces/cpp/mytestext.ini
+++ b/Examples/Namespaces/cpp/mytestext.ini
@@ -1,0 +1,4 @@
+; configuration for phpcpp module
+; priority=30
+extension=mytestext.so
+

--- a/Examples/Namespaces/namespase.php
+++ b/Examples/Namespaces/namespase.php
@@ -1,0 +1,24 @@
+<?php
+namespace NamespaceExample;
+
+/**
+  *  The namespace in Zend is only a part of the name defined in it a class or function.
+  *  see README.md
+  *  you can also run `php --re NamespaceExampleExt`
+  */
+
+
+echo '<pre>';
+var_dump(new TestClass());
+
+echo TestFunc();
+
+$refl = new \ReflectionClass('NamespaceExample\TestClass');
+echo "\nNamespaceName: ", $refl->getNamespaceName();
+
+echo "\nTestClass inNamespace: " ;
+var_export($refl->inNamespace());
+
+
+
+echo '</pre>';


### PR DESCRIPTION
PHP-CPP makes it possible very easy to define a PHP-namespace for your classes and functions.
To do this, just need to add the prefix **`NamespaceExample\`** to the name of a class or function:

``` c
        ...
        extension.add(
            "NamespaceExample\\TestClass", 
            Php::Class<MyTestClass>({
                Php::Public("myMethod", Php::Method<MyTestClass>(&MyTestClass::myMethod)),
            })
        );

        extension.add("NamespaceExample\\TestFunc", MyTestFunc);
        ...
```

Explanation of why this is so see [README](https://github.com/valmat/PHP-CPP/blob/namespace-example/Examples/Namespaces/README.md)

This Pull Request, I suggest example, documenting this opportunity.
