### PR TITLE
Small improvements

### DIFF
--- a/tests/cpp/Makefile
+++ b/tests/cpp/Makefile
@@ -42,8 +42,7 @@ NAME				=	extfortest
 #	this with a different fixed directory
 #
 
-#EXTENSION_DIR		=	$(shell php-config --extension-dir)
-EXTENSION_DIR		=	../..
+EXTENSION_DIR		=	$(shell php-config --extension-dir)
 
 
 #
@@ -87,10 +86,9 @@ LINKER				=	g++
 #	one: the PHP-CPP library), you should update the LINKER_DEPENDENCIES variable
 #	with a list of all flags that should be passed to the linker.
 #
+
 LIB_DIR=$(shell cd ../.. && pwd)
-#COMPILER_FLAGS		=	-Wall -c -O2 -std=c++11 -fpic -o
-#COMPILER_FLAGS		=	-Wall -c -g -std=c++11 -fpic -o
-COMPILER_FLAGS		=	-Wall -c -g -std=c++11 -fpic  -I. -I"${LIB_DIR}/include" -o
+COMPILER_FLAGS		=	-Wall -c -O2 -std=c++11 -fpic  -I"${LIB_DIR}/include" -o
 LINKER_FLAGS		=	-shared -L"${LIB_DIR}"
 LINKER_DEPENDENCIES	=	-lphpcpp
 
@@ -131,7 +129,7 @@ ${EXTENSION}:			${OBJECTS}
 ${OBJECTS}:
 						${COMPILER} ${COMPILER_FLAGS} $@ ${@:%.o=%.cpp}
 
-#	Do not install this extention
+#	Do not install this extension
 #install:		
 #						${CP} ${EXTENSION} ${EXTENSION_DIR}
 #						${CP} ${INI} ${INI_DIR}

--- a/tests/php/phpt/.gitignore
+++ b/tests/php/phpt/.gitignore
@@ -4,3 +4,4 @@
 *.out
 *.php
 *.sh
+*.mem

--- a/tests/run-tests.php
+++ b/tests/run-tests.php
@@ -1065,6 +1065,14 @@ function error_report($testname, $logname, $tested)
 
 function system_with_timeout($commandline, $env = null, $stdin = null)
 {
+	/*
+	 * Fixed for tests extension without installation
+	 * extension_for_tests
+	 */
+	if(isset($_SERVER["LD_LIBRARY_PATH"])) {
+		$env['LD_LIBRARY_PATH'] = $_SERVER["LD_LIBRARY_PATH"];
+	}
+	
 	global $leak_check, $cwd;
 
 	$data = '';
@@ -1792,27 +1800,6 @@ SCRIPT_FILENAME = " . $env['SCRIPT_FILENAME'] . "
 HTTP_COOKIE     = " . $env['HTTP_COOKIE'] . "
 COMMAND $cmd
 ";
-	//
-	/*
-	 * Fixed for tests extension without installation
-	 * extension_for_tests
-	 */
-	/*
-	$_LD_LIBRARY_PATH = isset($_SERVER["LD_LIBRARY_PATH"]) ?
-				('LD_LIBRARY_PATH="' . $_SERVER["LD_LIBRARY_PATH"] . "\"\nexport LD_LIBRARY_PATH")
-				
-					:
-				"###";
-	$_LD_LIBRARY_PATH_ex = isset($_SERVER["LD_LIBRARY_PATH"]) ?
-				('LD_LIBRARY_PATH="' . $_SERVER["LD_LIBRARY_PATH"] . "\" && export LD_LIBRARY_PATH && ")
-				
-					:
-				"";
-	*/
-
-	//$cmd = "LD_LIBRARY_PATH=\"/home/valmat/work/PHP-CPP\" && export LD_LIBRARY_PATH && $cmd";
-	//$cmd = "${_LD_LIBRARY_PATH_ex}$cmd";
-	
 
 	junit_start_timer($shortname);
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -22,6 +22,7 @@ function print_help() {
     echo "  -s <file>    Write output to <file>."
     echo "  -x           Sets 'SKIP_SLOW_TESTS' environmental variable."
     echo "  -o           Cancels sets 'SKIP_ONLINE_TESTS' (default set)."
+    echo "  -q           Quiet, no user interaction (same as environment NO_INTERACTION)."
     echo "  -v           Verbose mode."
     echo "  -h           This Help."
     echo
@@ -34,7 +35,7 @@ COMPILE_EXT=1
 OFFLINE=1
 EXT_NAME="extfortest.so"
 
-while getopts ":p:e:nw:a:d:g:ms:xovh" opt ;
+while getopts ":p:e:nw:a:d:g:ms:xoqvh" opt ;
 do
     case $opt in
         p)
@@ -70,6 +71,9 @@ do
         o)
             OFFLINE=0
             ;;
+        q)
+            SCR_OPT="$SCR_OPT -q"
+            ;;
         v)
             SCR_OPT="$SCR_OPT -v"
             ;;
@@ -88,11 +92,8 @@ done
 if [ 1 = $OFFLINE ]; then
     SCR_OPT="$SCR_OPT --offline"
 fi
-
+SCR_OPT="$SCR_OPT -d extension_dir=$PWD/ext_dir -d extension=$EXT_NAME"
 TEST_FILES=`find ./php/phpt -type f -name "*.phpt"`
-
-#RUN_SCR="$PHP_BIN -z ./cpp/$EXT_NAME"
-RUN_SCR="$PHP_BIN -d enable_dl=On -d extension_dir=$PWD/ext_dir -d extension=$EXT_NAME"
 
 
 # Create a local copy of the directory with the extension for run without installation
@@ -107,14 +108,13 @@ if [ 1 = $COMPILE_EXT ]; then
 fi
 
 
-
 LD_LIBRARY_PATH="$(cd $PWD/.. && echo $PWD):${LD_LIBRARY_PATH}"
 export LD_LIBRARY_PATH
 echo $LD_LIBRARY_PATH
 
-RUN_SCR="LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH\" && export LD_LIBRARY_PATH && $RUN_SCR"
+
 # run tests
-$PHP_BIN run-tests.php $SCR_OPT -p "$RUN_SCR" $TEST_FILES
+$PHP_BIN run-tests.php $SCR_OPT -p "$PHP_BIN" $TEST_FILES
 
 
 


### PR DESCRIPTION
Regained the ability to run the tests (script tests/test.sh) with option -m (Valgrind)
added option -q (Quiet)
Full range of options, see $ ./test.sh -h
Some other improvements (see diff)
