### PR TITLE
Add an bility to define inheritance for interfaces

### DIFF
--- a/include/interface.h
+++ b/include/interface.h
@@ -41,7 +41,18 @@ public:
         // return self
         return *this;
     }
-    
+
+    /**
+     *  Extends exisiting PHP interface
+     *
+     *  Note that the interface that you supply must already exist! Therefore
+     *  you can only supply interfaces that you created in your own extension.
+     *
+     *  @param  interface   Interface object
+     *  @return Interface   Same object to allow chaining
+     */
+    Interface &extends(const Interface &interface) { ClassBase::implements(interface); return *this; }
+
     /**
      *  The namespace needs to have access to the private ClassBase base
      *  class, to actually register the interface.


### PR DESCRIPTION
This small patch enables interface inheritance to complete basic OO model of PHP.

PHP side:

``` php
interface A {}
interface B extends A {}
class C implements B {}
```

C++ side

``` c++
Php::Interface a("A");
Php::Interface b("B");
Php::Class<C> c("C");

b.extends(a);
c.implements(b);
```
