### PR TITLE
Fixed Object Constructor.

### DIFF
--- a/include/object.h
+++ b/include/object.h
@@ -42,8 +42,10 @@ public:
     Object(const Value &value) : Value()
     {
         // string types are instantiated
-        if (value.isString()) instantiate(value);
-        
+        if (value.isString()) {
+            instantiate(value);
+            call("__construct");
+        }
         // otherwise copy the other object
         else operator=(value);
     }


### PR DESCRIPTION
The old copy constructor of Php::Object forgot the call("__construct")
