### PR TITLE
Add ref & refequals method for Php::Value

### DIFF
--- a/include/value.h
+++ b/include/value.h
@@ -389,6 +389,17 @@ public:
     Value ref() const {
         return Value(_val, true);
     }
+
+    /**
+     *  To check for reference equality.
+     *  @param  value
+     *  @return bool
+     */
+    bool refequals(const Value &value) const
+    {
+        return isRef() && _val == value._val;
+    }
+
     /**
      *  Get access to the raw buffer - you can use this for direct reading and
      *  writing to and from the buffer. Note that this only works for string


### PR DESCRIPTION
If you want get a reference of a value, you can use `ref` method. It will work correctly when patched #114.

You can use `refequals` method to check for reference equality. You can use it to compare whether two arrays are the same. There is no similar function in PHP, but we need it when we want to write a serialize program.
