### PR TITLE
Compilation issue with php53 on RHEL5

### DIFF
--- a/zend/objectimpl.h
+++ b/zend/objectimpl.h
@@ -85,7 +85,7 @@ public:
         zval *tmp;
     
         // initialize the properties, php 5.3 way
-        zend_hash_copy(_mixed->php.properties, &entry->default_properties, (copy_ctor_func_t) zval_property_ctor, &tmp, sizeof(zval*));
+        zend_hash_copy(_mixed->php.properties, &entry->default_properties, (copy_ctor_func_t) zval_add_ref, &tmp, sizeof(zval*));
 
 #else
 


### PR DESCRIPTION
Compiling on Red Hat Enterprise Linux 5 fails with the following error:
`zend/objectimpl.h:88:95: error: ‘zval_property_ctor’ was not declared in this scope
         zend_hash_copy(_mixed->php.properties, &entry->default_properties, (copy_ctor_func_t) zval_property_ctor, &tmp, sizeof(zval*));`
