### PR TITLE
PHP File Include Support #129

### DIFF
--- a/include/call.h
+++ b/include/call.h
@@ -26,6 +26,34 @@ inline bool  is_subclass_of(const Value &obj, const char *classname, size_t size
 inline bool  is_subclass_of(const Value &obj, const char *classname, bool allow_string = true) { return is_subclass_of(obj, classname, strlen(classname), allow_string); }
 inline bool  is_subclass_of(const Value &obj, const std::string &classname, bool allow_string = true) { return is_subclass_of(obj, classname.c_str(), classname.size(), allow_string); }
 
+enum class ExecutionType : int {
+    Include       =  2,
+    IncludeOnce   =  4,
+    Require       =  8,
+    RequireOnce   =  16
+};
+
+extern Value executeFile(const std::string execution, ExecutionType execType);
+
+inline Value include(const std::string execution)
+{
+    return executeFile(execution, ExecutionType::Include);
+}
+
+inline Value include_once(const std::string execution)
+{
+    return executeFile(execution, ExecutionType::IncludeOnce);
+}
+
+inline Value require(const std::string execution)
+{
+    return executeFile(execution, ExecutionType::Require);
+}
+
+inline Value require_once(const std::string execution)
+{
+    return executeFile(execution, ExecutionType::RequireOnce);
+}
 
 /**
  *  Call a function in PHP

--- a/zend/eval.cpp
+++ b/zend/eval.cpp
@@ -4,6 +4,7 @@
  *  This file holds the implementation for the Php::eval() function
  * 
  *  @author andot <https://github.com/andot>
+ *  @author tugrul <https://github.com/tugrul>
  */
 
 /**
@@ -63,6 +64,96 @@ Value eval(const std::string &phpCode)
         return retval ? Value(retval) : nullptr;
     }
 }
+
+Value executeFile(const std::string execution, ExecutionType execType)
+{
+    // we need the tsrm_ls variable
+    TSRMLS_FETCH();
+    
+    // resolve relative path to include path if exists
+    char *resolvedPath = zend_resolve_path(execution.c_str(), execution.length() TSRMLS_CC);
+    
+    int type = (int) execType;
+    
+    if (execType == ExecutionType::IncludeOnce || execType == ExecutionType::RequireOnce) {
+        // if the file is in include_path and included before 
+        if (resolvedPath != nullptr && zend_hash_exists(&EG(included_files), resolvedPath, ::strlen(resolvedPath) + 1)) {
+            return false;
+        }
+
+        type /= 2; 
+    }
+    
+    if (resolvedPath == nullptr) {
+        // use original path instead of non resolved path
+        resolvedPath = estrdup(execution.c_str());
+    }
+
+    zend_file_handle fileHandle;
+    
+    if (zend_stream_open(resolvedPath, &fileHandle TSRMLS_CC) == FAILURE) {
+        efree(resolvedPath);
+        return false;
+    }
+
+    if (!fileHandle.opened_path) {
+        fileHandle.opened_path = estrdup(resolvedPath);
+    }
+
+    // mark opened file as included
+    if (zend_hash_add_empty_element(&EG(included_files), fileHandle.opened_path, ::strlen(fileHandle.opened_path) + 1) == FAILURE) {
+        if (execType == ExecutionType::IncludeOnce || execType == ExecutionType::RequireOnce) {
+            efree(resolvedPath);
+            zend_file_handle_dtor(&fileHandle TSRMLS_CC); 
+            return false;
+        }
+    }
+    
+    zend_uint compilerOptions = CG(compiler_options);
+    
+    CG(compiler_options) = ZEND_COMPILE_DEFAULT;
+    // compile file and keep op_array for execution
+    zend_op_array *opArray = zend_compile_file(&fileHandle, type TSRMLS_CC); 
+    CG(compiler_options) = compilerOptions;
+    
+    efree(resolvedPath);
+    
+    if (EG(exception) != nullptr) {
+        throw OrigException(EG(exception) TSRMLS_CC);
+    }
+    
+    zval *retVal = nullptr;
+
+    // keep globals of previous stack frame
+    zval **origRetVal = EG(return_value_ptr_ptr);
+    zend_op **origOpline = EG(opline_ptr);
+    zend_op_array *origOpArray = EG(active_op_array);
+
+    // define globals of current stack frame
+    EG(return_value_ptr_ptr) = &retVal;
+    EG(active_op_array) = opArray;
+    
+    // build local symbol table if not exists
+    if (!EG(active_symbol_table)) {
+        zend_rebuild_symbol_table(TSRMLS_C);
+    }
+    
+    // execute the kept op_array
+    zend_execute(opArray TSRMLS_CC);
+    
+    // give back globals of previous stack frame
+    EG(return_value_ptr_ptr) = origRetVal;
+    EG(opline_ptr) = origOpline;
+    EG(active_op_array) = origOpArray;
+    
+    // populate exception if there was from execution
+    if (EG(exception) != nullptr) { 
+        throw OrigException(EG(exception) TSRMLS_CC);
+    }
+    
+    return retVal ? Value(retVal) : nullptr; 
+}
+
 
 /**
  *  End of namespace

--- a/zend/eval.cpp
+++ b/zend/eval.cpp
@@ -141,6 +141,9 @@ Value executeFile(const std::string execution, ExecutionType execType)
     // execute the kept op_array
     zend_execute(opArray TSRMLS_CC);
     
+    destroy_op_array(opArray TSRMLS_CC);
+    efree(opArray);
+    
     // give back globals of previous stack frame
     EG(return_value_ptr_ptr) = origRetVal;
     EG(opline_ptr) = origOpline;

--- a/zend/eval.cpp
+++ b/zend/eval.cpp
@@ -31,6 +31,8 @@ Value eval(const std::string &phpCode)
 
     // the return zval
     zval* retval = nullptr;
+    MAKE_STD_ZVAL(retval);
+    
     if (zend_eval_stringl_ex((char *)phpCode.c_str(), (int32_t)phpCode.length(), retval, (char *)"", 1 TSRMLS_CC) != SUCCESS)
     {
         // Do we want to throw an exception here? The original author


### PR DESCRIPTION
I fixed return value problem of `Php::eval` method.

I added a generic `Php::executeFile` method. I added some utility methods `Php::include`, `Php::require`, `Php::include_once` and `Php::require_once` depend to `Php::executeFile` method