### PR TITLE
Fix win static includes

### DIFF
--- a/include/call.h
+++ b/include/call.h
@@ -16,8 +16,8 @@ namespace Php {
  *  List of functions that are available for use in PHP
  */
 extern bool  class_exists(const char *classname, size_t size, bool autoload = true);
-inline bool  class_exists(const char *classname, bool autoload = true) { return class_exists(classname, strlen(classname), autoload); }
-inline bool  class_exists(const std::string &classname, bool autoload = true) { return class_exists(classname.c_str(), classname.size(), autoload); }
+static inline bool  class_exists(const char *classname, bool autoload = true) { return class_exists(classname, strlen(classname), autoload); }
+static inline bool  class_exists(const std::string &classname, bool autoload = true) { return class_exists(classname.c_str(), classname.size(), autoload); }
 extern Value constant(const char *constant);
 extern Value constant(const char *constant, size_t size);
 extern Value constant(const std::string &constant);
@@ -28,24 +28,24 @@ extern bool  defined(const char *constant);
 extern bool  defined(const char *constant, size_t size);
 extern bool  defined(const std::string &constant);
 extern bool  dl(const char *filename);
-inline bool  dl(const std::string &filename) { return dl(filename.c_str()); }
-inline bool  dl(const Value &filename) { return dl(filename.rawValue()); }
+static inline bool  dl(const std::string &filename) { return dl(filename.c_str()); }
+static inline bool  dl(const Value &filename) { return dl(filename.rawValue()); }
 extern Value eval(const char *phpCode);
-inline Value eval(const std::string &phpCode) { return eval(phpCode.c_str()); }
+static inline Value eval(const std::string &phpCode) { return eval(phpCode.c_str()); }
 extern Value include(const char *filename);
-inline Value include(const std::string &filename) { return include(filename.c_str()); }
+static inline Value include(const std::string &filename) { return include(filename.c_str()); }
 extern Value include_once(const char *filename);
-inline Value include_once(const std::string &filename) { return include_once(filename.c_str()); }
-inline bool  is_a(const Value &obj, const char *classname, size_t size, bool allow_string = false) { return obj.instanceOf(classname, size, allow_string); }
-inline bool  is_a(const Value &obj, const char *classname, bool allow_string = false) { return is_a(obj, classname, strlen(classname), allow_string); }
-inline bool  is_a(const Value &obj, const std::string &classname, bool allow_string = false) { return is_a(obj, classname.c_str(), classname.size(), allow_string); }
-inline bool  is_subclass_of(const Value &obj, const char *classname, size_t size, bool allow_string = true) { return obj.derivedFrom(classname, size, allow_string); }
-inline bool  is_subclass_of(const Value &obj, const char *classname, bool allow_string = true) { return is_subclass_of(obj, classname, strlen(classname), allow_string); }
-inline bool  is_subclass_of(const Value &obj, const std::string &classname, bool allow_string = true) { return is_subclass_of(obj, classname.c_str(), classname.size(), allow_string); }
+static inline Value include_once(const std::string &filename) { return include_once(filename.c_str()); }
+static inline bool  is_a(const Value &obj, const char *classname, size_t size, bool allow_string = false) { return obj.instanceOf(classname, size, allow_string); }
+static inline bool  is_a(const Value &obj, const char *classname, bool allow_string = false) { return is_a(obj, classname, strlen(classname), allow_string); }
+static inline bool  is_a(const Value &obj, const std::string &classname, bool allow_string = false) { return is_a(obj, classname.c_str(), classname.size(), allow_string); }
+static inline bool  is_subclass_of(const Value &obj, const char *classname, size_t size, bool allow_string = true) { return obj.derivedFrom(classname, size, allow_string); }
+static inline bool  is_subclass_of(const Value &obj, const char *classname, bool allow_string = true) { return is_subclass_of(obj, classname, strlen(classname), allow_string); }
+static inline bool  is_subclass_of(const Value &obj, const std::string &classname, bool allow_string = true) { return is_subclass_of(obj, classname.c_str(), classname.size(), allow_string); }
 extern Value require(const char *filename);
-inline Value require(const std::string &filename) { return require(filename.c_str()); }
+static inline Value require(const std::string &filename) { return require(filename.c_str()); }
 extern Value require_once(const char *filename);
-inline Value require_once(const std::string &filename) { return require_once(filename.c_str()); }
+static inline Value require_once(const std::string &filename) { return require_once(filename.c_str()); }
 
 /**
  *  Call a function in PHP
@@ -54,7 +54,7 @@ inline Value require_once(const std::string &filename) { return require_once(fil
  *  @return Value
  */
 template <typename ...Params>
-Value call(const char *name, Params&&... params)
+static inline Value call(const char *name, Params&&... params)
 {
     // the name can be turned into a Php::Value object, which implements
     // the operator () method to call it
@@ -79,31 +79,31 @@ Value call(const char *name, Params&&... params)
  *  make the code run on the highway), it is not expected that these functions
  *  are going to be used very often anyway.
  */
-inline Value array_key_exists(const Value &key, const Value &array) { return array.contains(key); }
-inline Value array_key_exists(int key, const Value &array) { return array.contains(key); }
-inline Value array_key_exists(const char *key, const Value &array) { return array.contains(key); }
-inline Value array_key_exists(const std::string &key, const Value &array) { return array.contains(key); }
-inline Value array_keys(const Value &value) { return call("array_keys", value); }
-inline Value array_push(const Value &array, const Value &value) { return call("array_push", array, value); }
-inline Value array_values(const Value &value) { return call("array_values", value); }
-inline Value count(const Value &value) { return call("count", value); }
-inline Value echo(const char *input) { out << input; return nullptr; }
-inline Value echo(const std::string &input) { out << input; return nullptr; }
-inline Value empty(const Value &value) { return value.isNull() || !value.boolValue(); }
-inline Value empty(const HashMember<std::string> &member) { return !member.exists() || empty(member.value()); }
-inline Value empty(const HashMember<int> &member) { return !member.exists() || empty(member.value()); }
-inline Value is_array(const Value &value) { return value.isArray(); }
-inline Value strlen(const Value &value) { return call("strlen", value); }
-inline void  unset(const HashMember<std::string> &member) { member.unset(); }
-inline void  unset(const HashMember<int> &member) { member.unset(); }
-inline void  unset(const HashMember<Value> &member) { member.unset(); }
+static inline Value array_key_exists(const Value &key, const Value &array) { return array.contains(key); }
+static inline Value array_key_exists(int key, const Value &array) { return array.contains(key); }
+static inline Value array_key_exists(const char *key, const Value &array) { return array.contains(key); }
+static inline Value array_key_exists(const std::string &key, const Value &array) { return array.contains(key); }
+static inline Value array_keys(const Value &value) { return call("array_keys", value); }
+static inline Value array_push(const Value &array, const Value &value) { return call("array_push", array, value); }
+static inline Value array_values(const Value &value) { return call("array_values", value); }
+static inline Value count(const Value &value) { return call("count", value); }
+static inline Value echo(const char *input) { out << input; return nullptr; }
+static inline Value echo(const std::string &input) { out << input; return nullptr; }
+static inline Value empty(const Value &value) { return value.isNull() || !value.boolValue(); }
+static inline Value empty(const HashMember<std::string> &member) { return !member.exists() || empty(member.value()); }
+static inline Value empty(const HashMember<int> &member) { return !member.exists() || empty(member.value()); }
+static inline Value is_array(const Value &value) { return value.isArray(); }
+static inline Value strlen(const Value &value) { return call("strlen", value); }
+static inline void  unset(const HashMember<std::string> &member) { member.unset(); }
+static inline void  unset(const HashMember<int> &member) { member.unset(); }
+static inline void  unset(const HashMember<Value> &member) { member.unset(); }
 
 /**
  *  The 'ini_get' function returns an IniValue, so that it can also be used
  *  before the PHP engine is started.
  */
-inline IniValue ini_get(const char* name) { return IniValue(name, false); }
-inline IniValue ini_get_orig(const char* name) { return IniValue(name, true); }
+static inline IniValue ini_get(const char* name) { return IniValue(name, false); }
+static inline IniValue ini_get_orig(const char* name) { return IniValue(name, true); }
 
 
 /**
@@ -115,10 +115,10 @@ inline IniValue ini_get_orig(const char* name) { return IniValue(name, true); }
 /**
  *  Define the isset function
  */
-inline Value isset(const Value &value) { return call("isset", value); }
-inline Value isset(const HashMember<std::string> &member) { return member.exists() && isset(member.value()); }
-inline Value isset(const HashMember<int> &member) { return member.exists() && isset(member.value()); }
-inline Value isset(const HashMember<Value> &member) { return member.exists() && isset(member.value()); }
+static inline Value isset(const Value &value) { return call("isset", value); }
+static inline Value isset(const HashMember<std::string> &member) { return member.exists() && isset(member.value()); }
+static inline Value isset(const HashMember<int> &member) { return member.exists() && isset(member.value()); }
+static inline Value isset(const HashMember<Value> &member) { return member.exists() && isset(member.value()); }
 
 /**
  *  Re-install the ISSET macro
@@ -129,4 +129,3 @@ inline Value isset(const HashMember<Value> &member) { return member.exists() && 
  *  End of namespace
  */
 }
-

--- a/zend/origexception.h
+++ b/zend/origexception.h
@@ -119,7 +119,7 @@ public:
  *  @param  exception
  *  @param  tsrm_ls
  */
-inline void process(Exception &exception TSRMLS_DC)
+static inline void process(Exception &exception TSRMLS_DC)
 {
     // is this a native exception?
     if (exception.native())


### PR DESCRIPTION
MSVC compiler will throw errors because one or more multiply defined symbols are found.