### PR TITLE
Fixed ambiguous call (MSVC compiler)

### DIFF
--- a/include/super.h
+++ b/include/super.h
@@ -44,7 +44,7 @@ public:
     Value operator[](const std::string &key)
     {
         // convert object to a value object, and retrieve the key
-        return value()[key];
+        return value().get(key);
     }
 
     /**
@@ -56,7 +56,7 @@ public:
     Value operator[](const char *key)
     {
         // convert object to a value object, and retrieve the key
-        return value()[key];
+        return value().get(key);
     }
 
     /**


### PR DESCRIPTION
- Re-factored operator[] access to the get() function.