### PR TITLE
Fixed HasCallStatic struct under MSVC

### DIFF
--- a/include/class.h
+++ b/include/class.h
@@ -387,7 +387,8 @@ private:
         typedef char one;
         typedef long two;
 
-        template <typename C> static one test( decltype(&C::__callStatic) ) ;
+        template <typename U, U> struct type_check;
+        template <typename C, typename Sign> static one test(type_check<Sign, &C::func >*);
         template <typename C> static two test(...);
 
     public:


### PR DESCRIPTION
-  Added type check struct because decltype doesn't work under MSVC
