### PR TITLE
Added case for lib64 folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,14 @@ PHP_BIN					=	$(shell ${PHP_CONFIG} --php-binary)
 
 INSTALL_PREFIX			=	/usr
 INSTALL_HEADERS			=	${INSTALL_PREFIX}/include
+
+MACHINE := $(shell uname -m)
+ifeq ($(MACHINE), x86_64)
+INSTALL_LIB				=	${INSTALL_PREFIX}/lib64
+endif
+ifeq ($(MACHINE), i686)
 INSTALL_LIB				=	${INSTALL_PREFIX}/lib
+endif
 
 
 #

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,7 @@ INSTALL_HEADERS			=	${INSTALL_PREFIX}/include
 MACHINE := $(shell uname -m)
 ifeq ($(MACHINE), x86_64)
 INSTALL_LIB				=	${INSTALL_PREFIX}/lib64
-endif
-ifeq ($(MACHINE), i686)
+else
 INSTALL_LIB				=	${INSTALL_PREFIX}/lib
 endif
 


### PR DESCRIPTION
`make install` places libraries into proper lib folder