### PR TITLE
Allow interfaces define static methods

### DIFF
--- a/include/interface.h
+++ b/include/interface.h
@@ -43,6 +43,22 @@ public:
     }
 
     /**
+     *  Add a - of course abstract - method to the interface
+     *  @param  name        Name of the method
+     *  @param  flags       Optional flags
+     *  @param  arguments   Optional description of the arguments
+     *  @return Interface   Same object to allow chaining
+     */
+    Interface &method(const char *name, int flags, const Arguments &arguments = {})
+    {
+        // call base
+        ClassBase::method(name, flags, arguments);
+
+        // return self
+        return *this;
+    }
+
+    /**
      *  Extends exisiting PHP interface
      *
      *  Note that the interface that you supply must already exist! Therefore

--- a/zend/classimpl.h
+++ b/zend/classimpl.h
@@ -414,7 +414,7 @@ public:
      *  @param  flags       Optional flags (like public or protected)
      *  @param  args        Description of the supported arguments
      */
-    void method(const char *name, int flags=0, const Arguments &args = {}) { _methods.push_back(std::make_shared<Method>(name, (flags & (MethodModifiers | Static)) | Abstract , args)); }
+    void method(const char *name, int flags=0, const Arguments &args = {}) { _methods.push_back(std::make_shared<Method>(name, (flags & (MethodModifiers | Static | Abstract)) , args)); }
 
     /**
      *  Add a property to the class


### PR DESCRIPTION
In PHP5.3+, allow this, I test it's OK.
See https://github.com/dreamsxin/cpphalcon/blob/master/include/DIInterface.h#L143