### PR TITLE
Add accessor for _zval_struct as void*

### DIFF
--- a/include/value.h
+++ b/include/value.h
@@ -1099,6 +1099,13 @@ public:
     bool derivedFrom(const char *classname, bool allowString = false) const { return derivedFrom(classname, strlen(classname), allowString); }
     bool derivedFrom(const std::string &classname, bool allowString = false) const { return derivedFrom(classname.c_str(), classname.size(), allowString); }
 
+    /**
+     * Returns a pointer to the internal zval structure
+     * To use this you need to include the php header files in your extension and cast this back to _zval_struct*
+     */
+    void* getInternalZVal() {
+        return _val;
+    }
 
 private:
     /**


### PR DESCRIPTION
I think it might be valuable to allow access to the _zval_struct of a Php::Value to developers wanting to write their own extension. Of course this creates the problem of having to deal with the zval and C header files etc, so I propose it might be of value to at least give access to the raw void* to the _zval_struct and have the user cast it back with their own copy of the header files, thus not exposing the zval to regular users who don't want it.
I am particularly interested in this to reuse resources created by other PHP extensions, e.g. PDO:
```C++
void test(Php::Parameters &p) {
    Php::Value orig = p[0];

    _zval_struct* zval = (_zval_struct*) orig.getInternalZVal();

    pdo_dbh_t* dbh = (pdo_dbh_t*)zend_object_store_get_object(zval TSRMLS_CC);

    Php::out << "Using PDO driver " << dbh->driver->driver_name << std::endl;
    if(strcmp(dbh->driver->driver_name, "pgsql") != 0) {
        Php::error << "This extension currently only supports pdo_pgsql database connections" << std::endl;
        return;
    }

    pdo_pgsql_db_handle* handle = (pdo_pgsql_db_handle*) dbh->driver_data;
    PGresult* result;

    if (!(result = PQexec(handle->server, "select 42"))) {
        Php::error << "Error while executing query" << std::endl;
        return;
    }

    auto status = PQresultStatus(result);
    if (status == PGRES_TUPLES_OK) {
        char* res = PQgetvalue(result, 0, 0);
        Php::out << "The answer to life, the universe and all the rest is " << res << std::endl;
    }

    PQclear(result);
}
```

The only other solution to access the zval I could come up with so far is deriving a custom class from Value and exposing the struct that way, but that only replaces one ugly cast (`void*` to `_zval_struct*`) with another (`reinterpret_cast<CustomValue*>`).