### PR TITLE
Added mkdir for lib folder and uninstall option in make.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,7 @@ ${PHP_STATIC_OBJECTS}:
 
 install:
 	${MKDIR} ${INSTALL_HEADERS}/phpcpp
+	${MKDIR} ${INSTALL_LIB}
 	${CP} phpcpp.h ${INSTALL_HEADERS}
 	${CP} include/*.h ${INSTALL_HEADERS}/phpcpp
 	if [ -e ${PHP_SHARED_LIBRARY} ]; then \
@@ -229,6 +230,10 @@ install:
 	if `which ldconfig`; then \
 		sudo ldconfig; \
 	fi
+
+uninstall:
+	${RM} ${INSTALL_HEADERS}/phpcpp*
+	${RM} ${INSTALL_LIB}/libphpcpp.*
 
 test:
 	mkdir -p tests/include/zts/phpcpp


### PR DESCRIPTION
There was no mkdir for $INSTALL_LIB in make file. This creates problem with "make install" for a custom $INSTALL_PREFIX. So added one mkdir.
Also added an uninstall option.
