### PR TITLE
Fix memory leak in ObjectImpl::ObjectImpl

### DIFF
--- a/zend/objectimpl.h
+++ b/zend/objectimpl.h
@@ -86,7 +86,10 @@ public:
     /**
      *  Destructor
      */
-    virtual ~ObjectImpl() = default;
+    virtual ~ObjectImpl()
+    {
+        zend_object_std_dtor(&_mixed->php);
+    }
 
     /**
      *  Destruct the object

--- a/zend/value.cpp
+++ b/zend/value.cpp
@@ -161,7 +161,7 @@ Value::Value(struct _zval_struct *val, bool ref)
     }
 
     // we see ourselves as reference too
-    Z_ADDREF_P(_val);
+    // Z_ADDREF_P(_val); // ZVAL_DUP will increment reference count for refcounted types
 
     // we're ready if we do not have to force it as a reference
     if (!ref || Z_ISREF_P(_val)) return;


### PR DESCRIPTION
See #249

ObjectImpl::ObjectImpl allocates ObjectImpl::MixedObject which is never freed.
