### PR TITLE
Fix compiler warnings

### DIFF
--- a/include/classtype.h
+++ b/include/classtype.h
@@ -23,7 +23,7 @@ namespace Php {
  *  used here.
  *
  */
-enum class PHPCPP_EXPORT ClassType {
+enum class ClassType {
     Regular     =   0x00,
     Abstract    =   0x20,
     Final       =   0x04,

--- a/include/errors.h
+++ b/include/errors.h
@@ -15,7 +15,7 @@ namespace Php {
 /**
  *  Supported types of errors, this is mostly a copy from Zend/zend_errors.h
  */
-enum class PHPCPP_EXPORT Error : int {
+enum class Error : int {
     Error                =   (1 << 0L),
     Warning              =   (1 << 1L),
     Parse                =   (1 << 2L),

--- a/include/thread_local.h
+++ b/include/thread_local.h
@@ -11,7 +11,7 @@
  */
 
 // are we dealing with an outdated sort of compiler?
-#ifdef _MSC_VER && _MSC_VER < 1500
+#if defined(_MSC_VER) && _MSC_VER < 1500
     // can't use thread_local, but we can use their
     // limited storage scope specifier in this case
     #define thread_local __declspec( thread )

--- a/include/type.h
+++ b/include/type.h
@@ -17,7 +17,7 @@ namespace Php {
  *  Supported types for variables
  *  The values are the same as the ones used internally in Zend
  */
-enum class PHPCPP_EXPORT Type : unsigned char {
+enum class Type : unsigned char {
     Undefined       =   0,  // Variable is not set
     Null            =   1,  // Null will allow any type
     False           =   2,  // Boolean false


### PR DESCRIPTION
1. enums cannot be exported, they are just like literal constants
2. #ifdef does not accept logical expressions
