### PR TITLE
Use information from PHP exception

### DIFF
--- a/include/exception.h
+++ b/include/exception.h
@@ -26,9 +26,19 @@ private:
 
     /**
      *  The PHP exception code
-     *  @var    int
+     *  @var    long int
      */
-    int _code;
+    long int _code;
+
+    /**
+     * PHP source file
+     */
+    std::string _file;
+
+    /**
+     * PHP source line
+     */
+    long int _line;
 
     /**
      *  Has this exception been processed by native C++ code?
@@ -41,7 +51,7 @@ public:
      *  Constructor
      *  @param  &string
      */
-    Exception(std::string message, int code = 0) : std::exception(), _message(std::move(message)), _code(code) {}
+    Exception(std::string message, long int code = 0) : std::exception(), _message(std::move(message)), _code(code) {}
 
     /**
      *  Destructor
@@ -67,6 +77,25 @@ public:
     }
 
     /**
+     * Returns the exception code
+     * @return long int
+     */
+    long int code() const _NOEXCEPT
+    {
+        return _code;
+    }
+
+    const std::string& file() const _NOEXCEPT
+    {
+        return _file;
+    }
+
+    long int line() const _NOEXCEPT
+    {
+        return _line;
+    }
+
+    /**
      *  Is this a native exception (one that was thrown from C++ code)
      *  @return bool
      */
@@ -84,6 +113,43 @@ public:
     {
         // this is not done here
         return false;
+    }
+
+protected:
+    /**
+     * Set the message of the exception
+     * @param msg
+     */
+    void setMessage(const std::string& msg)
+    {
+        _message = msg;
+    }
+
+    /**
+     * Set the exception code
+     * @param code
+     */
+    void setCode(long int code)
+    {
+        _code = code;
+    }
+
+    /**
+     * Set the source file
+     * @param file
+     */
+    void setFile(const std::string& file)
+    {
+        _file = file;
+    }
+
+    /**
+     * Set the source line
+     * @param line
+     */
+    void setLine(long int line)
+    {
+        _line = line;
     }
 };
 

--- a/zend/origexception.h
+++ b/zend/origexception.h
@@ -38,6 +38,19 @@ public:
      */
     OrigException(zend_object *object) : Exception(std::string{ ZSTR_VAL(object->ce->name), ZSTR_LEN(object->ce->name) })
     {
+        zval rv;
+        zval ex;
+        ZVAL_OBJ(&ex, object);
+        zend_string* msg  = zval_get_string(zend_read_property(Z_OBJCE(ex), &ex, ZEND_STRL("message"), 1, &rv));
+        zend_string* file = zval_get_string(zend_read_property(Z_OBJCE(ex), &ex, ZEND_STRL("file"), 1, &rv));
+        zend_long   code  = zval_get_long(zend_read_property(Z_OBJCE(ex), &ex, ZEND_STRL("code"), 1, &rv));
+        zend_long   line  = zval_get_long(zend_read_property(Z_OBJCE(ex), &ex, ZEND_STRL("line"), 1, &rv));
+        setMessage(std::string{ ZSTR_VAL(msg), ZSTR_LEN(msg) });
+        setCode(code);
+        setFile(std::string{ ZSTR_VAL(file), ZSTR_LEN(file) });
+        setLine(line);
+        zend_string_release(msg);
+        zend_string_release(file);
     }
 
     /**


### PR DESCRIPTION
When catching an exception thrown in PHP, the C++ code has now access to the original message, exception code, source file, and source line.

Code:

```php
my_catch_exception_function(
        function($a, $b, $c)
        {
                throw new Exception("Sample exception");
        }
);
```

```c++
void my_catch_exception_function(Php::Parameters& params)
{
	Php::Value callback = params[0];

	if (!callback.isCallable()) {
		throw Php::Exception("Parameter 0 is not a function");
	}

	try {
		callback("some"," example", "parameters");
	}
	catch (const Php::Exception& exception) {
		std::cout << "Exception caught in CPP code: " << exception.message() << std::endl;
	}
}
```

The code used to display:

Exception caught in CPP code:  Exception

Now:

Exception caught in CPP code: Sample exception