### PR TITLE
Fix invalid read in ~Exception

### DIFF
--- a/include/exception.h
+++ b/include/exception.h
@@ -41,7 +41,7 @@ public:
      *  Constructor
      *  @param  &string
      */
-    Exception(std::string message, int code = 0) : std::exception(), _message(std::move(message)), _code(code) {}
+    Exception(const std::string& message, int code = 0) : std::exception(), _message(std::move(message)), _code(code) {}
 
     /**
      *  Destructor


### PR DESCRIPTION
See #254:

```
==27493== Invalid read of size 8
==27493==    at 0xB2E76C3: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==27493==    by 0xF4CC5F9: Php::Exception::~Exception() (in /PHP-CPP/test/phpcpptest.so)
==27493==    by 0xB25588E: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==27493==    by 0xF4C71DD: void Php::ZendCallable::invoke<&(test254())>(_zend_execute_data*, _zval_struct*) (in /PHP-CPP/test/phpcpptest.so)
==27493==    by 0xB8053D: ZEND_DO_ICALL_SPEC_HANDLER (zend_vm_execute.h:586)
==27493==    by 0xB7FD1B: execute_ex (zend_vm_execute.h:414)
==27493==    by 0xB7FF1C: zend_execute (zend_vm_execute.h:458)
==27493==    by 0xB1771A: zend_execute_scripts (zend.c:1427)
==27493==    by 0xA51BE8: php_execute_script (main.c:2494)
==27493==    by 0xBEF328: do_cli (php_cli.c:974)
==27493==    by 0xBF07CB: main (php_cli.c:1344)
==27493==  Address 0xfae69d0 is 0 bytes after a block of size 176 alloc'd
==27493==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27493==    by 0xB25441F: __cxa_allocate_exception (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==27493==    by 0xF75682C: Php::do_exec(_zval_struct const*, _zval_struct*, int, _zval_struct*) (value.cpp:749)
==27493==    by 0xF757096: Php::Value::exec(int, Php::Value*) const (value.cpp:877)
==27493==    by 0xF4CE88D: Php::Value Php::Value::operator()<Php::Value const&, Php::Value const&>(Php::Value const&, Php::Value const&) const (in /PHP-CPP/test/phpcpptest.so)
==27493==    by 0xF4CDAD2: Php::Value Php::call<Php::Value const&, Php::Value const&>(char const*, Php::Value const&, Php::Value const&) (in /PHP-CPP/test/phpcpptest.so)
==27493==    by 0xF4CD87F: Php::array_push(Php::Value const&, Php::Value const&) (in /PHP-CPP/test/phpcpptest.so)
==27493==    by 0xF4CB9E9: test254() (in /PHP-CPP/test/phpcpptest.so)
==27493==    by 0xF4C7119: void Php::ZendCallable::invoke<&(test254())>(_zend_execute_data*, _zval_struct*) (in /PHP-CPP/test/phpcpptest.so)
==27493==    by 0xB8053D: ZEND_DO_ICALL_SPEC_HANDLER (zend_vm_execute.h:586)
==27493==    by 0xB7FD1B: execute_ex (zend_vm_execute.h:414)
==27493==    by 0xB7FF1C: zend_execute (zend_vm_execute.h:458)
==27493==
```
