### PR TITLE
Use EG(scope) to access properties

### DIFF
--- a/zend/value.cpp
+++ b/zend/value.cpp
@@ -1564,7 +1564,7 @@ Value Value::get(const char *key, int size) const
         zval rv;
 
         // read the property
-        zval *property = zend_read_property(nullptr, _val, key, size, 0, &rv);
+        zval *property = zend_read_property(EG(scope), _val, key, size, 0, &rv);
 
         // wrap in value
         return Value(property);
@@ -1633,7 +1633,7 @@ void Value::setRaw(const char *key, int size, const Value &value)
         SEPARATE_ZVAL_IF_NOT_REF(_val);
 
         // update the property
-        zend_update_property(nullptr, _val, key, size, value._val);
+        zend_update_property(EG(scope), _val, key, size, value._val);
     }
     else
     {


### PR DESCRIPTION
This should fix #260.

The issue was that zend_read_property/zend_update_property used NULL as a scope, making protected/private properties inaccessible.
