### PR TITLE
Make inlines static and unexport them

### DIFF
--- a/include/call.h
+++ b/include/call.h
@@ -16,8 +16,8 @@ namespace Php {
  *  List of functions that are available for use in PHP
  */
 extern PHPCPP_EXPORT    bool  class_exists(const char *classname, size_t size, bool autoload = true);
-inline PHPCPP_EXPORT    bool  class_exists(const char *classname, bool autoload = true) { return class_exists(classname, strlen(classname), autoload); }
-inline PHPCPP_EXPORT    bool  class_exists(const std::string &classname, bool autoload = true) { return class_exists(classname.c_str(), classname.size(), autoload); }
+static inline           bool  class_exists(const char *classname, bool autoload = true) { return class_exists(classname, strlen(classname), autoload); }
+static inline           bool  class_exists(const std::string &classname, bool autoload = true) { return class_exists(classname.c_str(), classname.size(), autoload); }
 extern PHPCPP_EXPORT    Value constant(const char *constant);
 extern PHPCPP_EXPORT    Value constant(const char *constant, size_t size);
 extern PHPCPP_EXPORT    Value constant(const std::string &constant);
@@ -28,24 +28,24 @@ extern PHPCPP_EXPORT    bool  defined(const char *constant);
 extern PHPCPP_EXPORT    bool  defined(const char *constant, size_t size);
 extern PHPCPP_EXPORT    bool  defined(const std::string &constant);
 extern PHPCPP_EXPORT    bool  dl(const char *filename, bool persistent = false);
-inline PHPCPP_EXPORT    bool  dl(const std::string &filename, bool persistent = false) { return dl(filename.c_str(), persistent); }
-inline PHPCPP_EXPORT    bool  dl(const Value &filename, bool persistent = false) { return dl(filename.rawValue(), persistent); }
+static inline           bool  dl(const std::string &filename, bool persistent = false) { return dl(filename.c_str(), persistent); }
+static inline           bool  dl(const Value &filename, bool persistent = false) { return dl(filename.rawValue(), persistent); }
 extern PHPCPP_EXPORT    Value eval(const char *phpCode);
-inline PHPCPP_EXPORT    Value eval(const std::string &phpCode) { return eval(phpCode.c_str()); }
+static inline           Value eval(const std::string &phpCode) { return eval(phpCode.c_str()); }
 extern PHPCPP_EXPORT    Value include(const char *filename);
-inline PHPCPP_EXPORT    Value include(const std::string &filename) { return include(filename.c_str()); }
+static inline           Value include(const std::string &filename) { return include(filename.c_str()); }
 extern PHPCPP_EXPORT    Value include_once(const char *filename);
-inline PHPCPP_EXPORT    Value include_once(const std::string &filename) { return include_once(filename.c_str()); }
-inline PHPCPP_EXPORT    bool  is_a(const Value &obj, const char *classname, size_t size, bool allow_string = false) { return obj.instanceOf(classname, size, allow_string); }
-inline PHPCPP_EXPORT    bool  is_a(const Value &obj, const char *classname, bool allow_string = false) { return is_a(obj, classname, strlen(classname), allow_string); }
-inline PHPCPP_EXPORT    bool  is_a(const Value &obj, const std::string &classname, bool allow_string = false) { return is_a(obj, classname.c_str(), classname.size(), allow_string); }
-inline PHPCPP_EXPORT    bool  is_subclass_of(const Value &obj, const char *classname, size_t size, bool allow_string = true) { return obj.derivedFrom(classname, size, allow_string); }
-inline PHPCPP_EXPORT    bool  is_subclass_of(const Value &obj, const char *classname, bool allow_string = true) { return is_subclass_of(obj, classname, strlen(classname), allow_string); }
-inline PHPCPP_EXPORT    bool  is_subclass_of(const Value &obj, const std::string &classname, bool allow_string = true) { return is_subclass_of(obj, classname.c_str(), classname.size(), allow_string); }
+static inline           Value include_once(const std::string &filename) { return include_once(filename.c_str()); }
+static inline           bool  is_a(const Value &obj, const char *classname, size_t size, bool allow_string = false) { return obj.instanceOf(classname, size, allow_string); }
+static inline           bool  is_a(const Value &obj, const char *classname, bool allow_string = false) { return is_a(obj, classname, strlen(classname), allow_string); }
+static inline           bool  is_a(const Value &obj, const std::string &classname, bool allow_string = false) { return is_a(obj, classname.c_str(), classname.size(), allow_string); }
+static inline           bool  is_subclass_of(const Value &obj, const char *classname, size_t size, bool allow_string = true) { return obj.derivedFrom(classname, size, allow_string); }
+static inline           bool  is_subclass_of(const Value &obj, const char *classname, bool allow_string = true) { return is_subclass_of(obj, classname, strlen(classname), allow_string); }
+static inline           bool  is_subclass_of(const Value &obj, const std::string &classname, bool allow_string = true) { return is_subclass_of(obj, classname.c_str(), classname.size(), allow_string); }
 extern PHPCPP_EXPORT    Value require(const char *filename);
-inline PHPCPP_EXPORT    Value require(const std::string &filename) { return require(filename.c_str()); }
+static inline           Value require(const std::string &filename) { return require(filename.c_str()); }
 extern PHPCPP_EXPORT    Value require_once(const char *filename);
-inline PHPCPP_EXPORT    Value require_once(const std::string &filename) { return require_once(filename.c_str()); }
+static inline           Value require_once(const std::string &filename) { return require_once(filename.c_str()); }
 extern PHPCPP_EXPORT    Value set_exception_handler(const std::function<Value(Parameters &params)> &handler);
 extern PHPCPP_EXPORT    Value set_error_handler(const std::function<Value(Parameters &params)> &handler, Error error = Error::All);
 extern PHPCPP_EXPORT    Value error_reporting(Error error);
@@ -83,31 +83,31 @@ Value call(const char *name, Params&&... params)
  *  make the code run on the highway), it is not expected that these functions
  *  are going to be used very often anyway.
  */
-inline PHPCPP_EXPORT    Value array_key_exists(const Value &key, const Value &array) { return array.contains(key); }
-inline PHPCPP_EXPORT    Value array_key_exists(int key, const Value &array) { return array.contains(key); }
-inline PHPCPP_EXPORT    Value array_key_exists(const char *key, const Value &array) { return array.contains(key); }
-inline PHPCPP_EXPORT    Value array_key_exists(const std::string &key, const Value &array) { return array.contains(key); }
-inline PHPCPP_EXPORT    Value array_keys(const Value &value) { return call("array_keys", value); }
-inline PHPCPP_EXPORT    Value array_push(const Value &array, const Value &value) { return call("array_push", array, value); }
-inline PHPCPP_EXPORT    Value array_values(const Value &value) { return call("array_values", value); }
-inline PHPCPP_EXPORT    Value count(const Value &value) { return call("count", value); }
-inline PHPCPP_EXPORT    Value echo(const char *input) { out << input; return nullptr; }
-inline PHPCPP_EXPORT    Value echo(const std::string &input) { out << input; return nullptr; }
-inline PHPCPP_EXPORT    Value empty(const Value &value) { return value.isNull() || !value.boolValue(); }
-inline PHPCPP_EXPORT    Value empty(const HashMember<std::string> &member) { return !member.exists() || empty(member.value()); }
-inline PHPCPP_EXPORT    Value empty(const HashMember<int> &member) { return !member.exists() || empty(member.value()); }
-inline PHPCPP_EXPORT    Value is_array(const Value &value) { return value.isArray(); }
-inline PHPCPP_EXPORT    Value strlen(const Value &value) { return call("strlen", value); }
-inline PHPCPP_EXPORT    void  unset(const HashMember<std::string> &member) { member.unset(); }
-inline PHPCPP_EXPORT    void  unset(const HashMember<int> &member) { member.unset(); }
-inline PHPCPP_EXPORT    void  unset(const HashMember<Value> &member) { member.unset(); }
+static inline Value array_key_exists(const Value &key, const Value &array) { return array.contains(key); }
+static inline Value array_key_exists(int key, const Value &array) { return array.contains(key); }
+static inline Value array_key_exists(const char *key, const Value &array) { return array.contains(key); }
+static inline Value array_key_exists(const std::string &key, const Value &array) { return array.contains(key); }
+static inline Value array_keys(const Value &value) { return call("array_keys", value); }
+static inline Value array_push(const Value &array, const Value &value) { return call("array_push", array, value); }
+static inline Value array_values(const Value &value) { return call("array_values", value); }
+static inline Value count(const Value &value) { return call("count", value); }
+static inline Value echo(const char *input) { out << input; return nullptr; }
+static inline Value echo(const std::string &input) { out << input; return nullptr; }
+static inline Value empty(const Value &value) { return value.isNull() || !value.boolValue(); }
+static inline Value empty(const HashMember<std::string> &member) { return !member.exists() || empty(member.value()); }
+static inline Value empty(const HashMember<int> &member) { return !member.exists() || empty(member.value()); }
+static inline Value is_array(const Value &value) { return value.isArray(); }
+static inline Value strlen(const Value &value) { return call("strlen", value); }
+static inline void  unset(const HashMember<std::string> &member) { member.unset(); }
+static inline void  unset(const HashMember<int> &member) { member.unset(); }
+static inline void  unset(const HashMember<Value> &member) { member.unset(); }
 
 /**
  *  The 'ini_get' function returns an IniValue, so that it can also be used
  *  before the PHP engine is started.
  */
-inline PHPCPP_EXPORT    IniValue ini_get(const char* name) { return IniValue(name, false); }
-inline PHPCPP_EXPORT    IniValue ini_get_orig(const char* name) { return IniValue(name, true); }
+static inline IniValue ini_get(const char* name) { return IniValue(name, false); }
+static inline IniValue ini_get_orig(const char* name) { return IniValue(name, true); }
 
 
 /**
@@ -119,10 +119,10 @@ inline PHPCPP_EXPORT    IniValue ini_get_orig(const char* name) { return IniValu
 /**
  *  Define the isset function
  */
-inline PHPCPP_EXPORT    Value isset(const Value &value) { return call("isset", value); }
-inline PHPCPP_EXPORT    Value isset(const HashMember<std::string> &member) { return member.exists() && isset(member.value()); }
-inline PHPCPP_EXPORT    Value isset(const HashMember<int> &member) { return member.exists() && isset(member.value()); }
-inline PHPCPP_EXPORT    Value isset(const HashMember<Value> &member) { return member.exists() && isset(member.value()); }
+static inline Value isset(const Value &value) { return call("isset", value); }
+static inline Value isset(const HashMember<std::string> &member) { return member.exists() && isset(member.value()); }
+static inline Value isset(const HashMember<int> &member) { return member.exists() && isset(member.value()); }
+static inline Value isset(const HashMember<Value> &member) { return member.exists() && isset(member.value()); }
 
 /**
  *  Re-install the ISSET macro

--- a/zend/origexception.h
+++ b/zend/origexception.h
@@ -96,7 +96,7 @@ public:
  *  Global function to process an exception
  *  @param  exception
  */
-inline void process(Exception &exception)
+static inline void process(Exception &exception)
 {
     // is this a native exception?
     if (exception.native())


### PR DESCRIPTION
1. Make `inline` functions `static` so that that the compiler does not have to generate a copy of the inline function (by default inline functions have external linkage)
2. Unexport inline functions — they are meant to be inlined at the call site, therefore there is no reason to include them into the library (such functions will only increase the size of the library but won't actually be used).
3. Solve the compilation issue with MSVC (see #178)
4. It is [not recommended](https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/CppRuntimeEnv/Articles/SymbolVisibility.html) to export inline functions anyway.
