### PR TITLE
Fix segfault when accessing superglobals

### DIFF
--- a/zend/super.cpp
+++ b/zend/super.cpp
@@ -15,13 +15,29 @@ namespace Php {
 /**
  *  A number of super-globals are always accessible
  */
-Super POST      (TRACK_VARS_POST,    "_POST");
-Super GET       (TRACK_VARS_GET,     "_GET");
-Super COOKIE    (TRACK_VARS_COOKIE,  "_COOKIE");
-Super SERVER    (TRACK_VARS_SERVER,  "_SERVER");
-Super ENV       (TRACK_VARS_ENV,     "_ENV");
-Super FILES     (TRACK_VARS_FILES,   "_FILES");
-Super REQUEST   (TRACK_VARS_REQUEST, "_REQUEST");
+Super POST      ("_POST");
+Super GET       ("_GET");
+Super COOKIE    ("_COOKIE");
+Super SERVER    ("_SERVER");
+Super ENV       ("_ENV");
+Super FILES     ("_FILES");
+Super REQUEST   ("_REQUEST");
+
+/**
+ * Calls @c zend_is_auto_global() if necessary and looks up this superglobal in the symbol table
+ * @internal
+ */
+struct _zval_struct* Super::resolve()
+{
+    if (!_ziag_called) {
+        // call zend_is_auto_global to ensure that the just-in-time globals are loaded
+        // this needs to be done only once
+        zend_is_auto_global(String(_name));
+        _ziag_called = true;
+    }
+
+    return zend_hash_str_find(&EG(symbol_table), _name, std::strlen(_name));
+}
 
 /**
  *  Convert object to a value
@@ -29,17 +45,29 @@ Super REQUEST   (TRACK_VARS_REQUEST, "_REQUEST");
  */
 Value Super::value()
 {
-    // call zend_is_auto_global to ensure that the just-in-time globals are loaded
-    if (_name) {
-        // make the variable an auto global
-        zend_is_auto_global(String{ _name });
+    zval* v = resolve();
+    return v ? Value(v) : Value();
+}
 
-        // reset because we only need to do this once
-        _name = nullptr;
+/**
+ * Returns @c SUPERGLOBAL[key].
+ * If there is no @c key index, it gets created
+ */
+Value Super::getKey(const char* key, std::size_t len)
+{
+    zval* arr = resolve();
+    if (arr && Z_TYPE_P(arr) == IS_ARRAY) {
+        zval* v = zend_symtable_str_find(Z_ARRVAL_P(arr), key, len);
+        if (!v) {
+            zval empty;
+            ZVAL_NULL(&empty);
+            v = zend_symtable_str_update(Z_ARRVAL_P(arr), key, len, &empty);
+        }
+
+        return Value(v, true);
     }
 
-    // create a value object that wraps around the actual zval
-    return &PG(http_globals)[_index];
+    return Value();
 }
 
 /**


### PR DESCRIPTION
See #229 

In addition to that, makes assignment to array items of superglobals work, ie

```c++
Php::REQUEST["key"] = somevalue;
```
