### PR TITLE
Simplify Callable implementation

### DIFF
--- a/zend/callable.cpp
+++ b/zend/callable.cpp
@@ -29,7 +29,7 @@ void Callable::invoke(INTERNAL_FUNCTION_PARAMETERS)
 
     // Sanity check
     assert(info[argc+1].class_name == nullptr && info[argc+1].name == nullptr);
-    assert(info[argc+1].class_name != nullptr && info[argc+2].name == nullptr);
+    assert(info[argc+2].class_name != nullptr && info[argc+2].name == nullptr);
 
     // the callable we are retrieving
     Callable *callable = reinterpret_cast<Callable*>(info[argc+2].class_name);

--- a/zend/callable.cpp
+++ b/zend/callable.cpp
@@ -14,16 +14,6 @@
 namespace Php {
 
 /**
- *  Map function names to their implementation
- *
- *  This is braindead, there should be a way to get this information
- *  from the "This" zval in the execute_data, I just can't find it
- *  @todo   Find a better way for this
- *  @var    std::map<std::string, Callable*>
- */
-static std::map<std::string, Callable*> callables;
-
-/**
  *  Function that is called by the Zend engine every time that a function gets called
  *  @param  ht
  *  @param  return_value
@@ -34,34 +24,22 @@ static std::map<std::string, Callable*> callables;
  */
 void Callable::invoke(INTERNAL_FUNCTION_PARAMETERS)
 {
-    // find the function name
-    const char *name = get_active_function_name();
-    const char *classname = get_active_class_name(nullptr);
+    uint32_t argc       = EX(func)->common.num_args;
+    zend_arg_info* info = EX(func)->common.arg_info;
+
+    // Sanity check
+    assert(info[argc+1].class_name == nullptr && info[argc+1].name == nullptr);
+    assert(info[argc+1].class_name != nullptr && info[argc+2].name == nullptr);
 
     // the callable we are retrieving
-    Callable *callable = nullptr;
-
-    // are we invoking a member function?
-    if (classname && classname[0])
-    {
-        // construct the full name to search for
-        auto fullname = std::string{ classname } + "::" + name;
-
-        // and find the callable in the map
-        callable = callables.find(fullname)->second;
-    }
-    else
-    {
-        // retrieve the callable from the map without mangling
-        callable = callables.find(name)->second;
-    }
+    Callable *callable = reinterpret_cast<Callable*>(info[argc+2].class_name);
 
     // check if sufficient parameters were passed (for some reason this check
     // is not done by Zend, so we do it here ourselves)
     if (ZEND_NUM_ARGS() < callable->_required)
     {
         // PHP itself only generates a warning when this happens, so we do the same too
-        Php::warning << name << "() expects at least " << callable->_required << " parameter(s), " << ZEND_NUM_ARGS() << " given" << std::flush;
+        Php::warning << get_active_function_name() << "() expects at least " << callable->_required << " parameter(s), " << ZEND_NUM_ARGS() << " given" << std::flush;
 
         // and we return null
         RETURN_NULL();
@@ -109,22 +87,7 @@ void Callable::initialize(zend_function_entry *entry, const char *classname, int
     }
     else
     {
-        // if we have a classname we have to combine the two for a unique name
-        // otherwise similar functions  - like __construct - will overwrite functions
-        // declared before
-        if (classname)
-        {
-            // build the unique name
-            auto name = std::string{ classname } + "::" + _name;
-
-            // add it to the map
-            callables[name] = const_cast<Callable*>(this);
-        }
-        else
-        {
-            // no need to mangle the name
-            callables[_name] = const_cast<Callable*>(this);
-        }
+        _argv[_argc + 2].class_name = reinterpret_cast<const char*>(this);
 
         // we use our own invoke method, which does a lookup
         // in the map we just installed ourselves in

--- a/zend/callable.h
+++ b/zend/callable.h
@@ -35,7 +35,7 @@ public:
         _callback(callback),
         _name(name),
         _argc(arguments.size()),
-        _argv(new zend_internal_arg_info[_argc + 1])
+        _argv(new zend_internal_arg_info[_argc + 3])
     {
         // the first record is initialized with information about the function,
         // so we skip that here
@@ -50,6 +50,11 @@ public:
             // fill the arg info
             fill(&_argv[i++], argument);
         }
+
+        _argv[i].class_name   = nullptr;
+        _argv[i].name         = nullptr;
+        _argv[i+1].class_name = nullptr;
+        _argv[i+1].name       = nullptr;
     }
 
     /**
@@ -65,14 +70,7 @@ public:
      *  Copy constructor
      *  @param  that
      */
-    Callable(const Callable &that) :
-        _name(that._name),
-        _return(that._return),
-        _required(that._required),
-        _argc(that._argc),
-        _argv(nullptr) {}
-        // @todo: we have no arguments after copy? is this correct?
-        // we do have the argument count though...
+    Callable(const Callable &that) = delete;
 
     /**
      *  Move constructor

--- a/zend/method.h
+++ b/zend/method.h
@@ -55,7 +55,7 @@ public:
      *  Copy and move constructors
      *  @param  that
      */
-    Method(const Method &that) : Callable(that), _type(that._type), _flags(that._flags), _callback(that._callback) {}
+    Method(const Method &that) = delete;
     Method(Method &&that) : Callable(std::move(that)), _type(that._type), _flags(that._flags), _callback(that._callback) {}
 
     /**

--- a/zend/nativefunction.h
+++ b/zend/nativefunction.h
@@ -41,7 +41,7 @@ public:
      *  Copy constructor
      *  @param  that
      */
-    NativeFunction(const NativeFunction &that) : Callable(that), _function(that._function), _type(that._type) {}
+    NativeFunction(const NativeFunction &that) = delete;
 
     /**
      *  Move constructor


### PR DESCRIPTION
This PR addresses the following comment found in the code of zend/callable.cpp:

```c++
 /**
 *  Map function names to their implementation
 *
 *  This is braindead, there should be a way to get this information
 *  from the "This" zval in the execute_data, I just can't find it
 *  @todo   Find a better way for this
 *  @var    std::map<std::string, Callable*>
 */
static std::map<std::string, Callable*> callables;
```

Though the required information cannot be found in `EG(This)` (especially for function calls — functions have no `$this`), yet still there is a way to store and retrieve that information in Zend structures.

The idea is that we allocate two arginfo's more than necessary:
```diff
-        _argv(new zend_internal_arg_info[_argc + 1])
+        _argv(new zend_internal_arg_info[_argc + 3])
```

The first extra arginfo will be a sentinel with its `name` and `class_name` set to `nullptr`, the second one will store `this` of the Callable itself in `class_name` (and `name` will be `nullptr`).

If necessary, we can live without the sentinel and save some memory (12 bytes for 32 bit, 24 bytes for 64 bit), it is used only to simplify debugging.

The initialization becomes as simple as that:
```c++
_argv[_argc + 2].class_name = reinterpret_cast<const char*>(this);
```

Retrieval of the Callable:
```c++
uint32_t argc       = EX(func)->common.num_args;
zend_arg_info* info = EX(func)->common.arg_info;

// Sanity check
assert(info[argc+1].class_name == nullptr && info[argc+1].name == nullptr);
assert(info[argc+2].class_name != nullptr && info[argc+2].name == nullptr);

Callable *callable = reinterpret_cast<Callable*>(info[argc+2].class_name);
```

Bonus: since this code was asking for trouble:
```c++
    Callable(const Callable &that) :
        _name(that._name),
        _return(that._return),
        _required(that._required),
        _argc(that._argc),
        _argv(nullptr) {}
        // @todo: we have no arguments after copy? is this correct?
        // we do have the argument count though...
```

I have marked that copy constructor and other copy constructors depending on it as deleted. It looks like copying of callables was not used by the library…

This modified implementation [successfully passes](https://travis-ci.org/sjinks/PHP-CPP/builds/186696952) all tests (BTW, if you are interested in setting up Travis CI, I have tests to share :wink: )
