### PR TITLE
Refactor Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,12 +180,12 @@ shared/common shared/zend static/common static/zend:
 
 clean:
 	$(RM) $(PHP_SHARED_LIBRARY_BASE) $(PHP_SHARED_LIBRARY_SONAME) $(PHP_SHARED_LIBRARY) $(PHP_STATIC_LIBRARY) $(OBJECTS)
-	-$(RM) -r shared static
+	-$(RM) shared/common shared/zend static/common static/zend shared static
 
 clean: clean-deps
 
 clean-deps:
-	-rm -f $(SOURCE_DEPS)
+	-$(RM) $(SOURCE_DEPS)
 
 ifeq (,$(findstring clean,$(MAKECMDGOALS)))
 -include $(SOURCE_DEPS)
@@ -220,6 +220,6 @@ uninstall:
 	$(RM) "$(DESTDIR_HEADERS)/phpcpp.h"
 	$(RM) $(addprefix $(DESTDIR_HEADERS)/ $(notdir $(HEADERS)))
 	$(RM) "$(DESTDIR_LIB)/$(PHP_SHARED_LIBRARY)" "$(DESTDIR_LIB)/$(PHP_SHARED_LIBRARY_BASE)" "$(DESTDIR_LIB)/$(PHP_SHARED_LIBRARY_SONAME)"
-	-$(RM) -r "$(DESTDIR_HEADERS)/phpcpp.h"
+	-$(RM) "$(DESTDIR_HEADERS)/phpcpp.h"
 
 .PHONY: shared_directories static_directories clean clean-deps install uninstall all release phpcpp

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ install:
 	$(MKDIR) "$(DESTDIR_HEADERS)/phpcpp"
 	$(MKDIR) "$(DESTDIR_LIB)"
 	$(CP) phpcpp.h "$(DESTDIR_HEADERS)"
-	$(CP) $(notdir $(HEADERS)) "$(DESTDIR_HEADERS)/phpcpp/"
+	$(CP) $(HEADERS) "$(DESTDIR_HEADERS)/phpcpp/"
 	if [ -e $(PHP_SHARED_LIBRARY) ]; then \
 		$(CP) $(PHP_SHARED_LIBRARY) "$(DESTDIR_LIB)/"; \
 		$(LN) "$(DESTDIR_LIB)/$(PHP_SHARED_LIBRARY)" "$(DESTDIR_LIB)/$(PHP_SHARED_LIBRARY_SONAME)"; \


### PR DESCRIPTION
# The Most Important Changes

1. Fixed dependency generation. Originally the `-MD` switch was passed to the compiler to generate the dependency information but that information was never used. This is the most important change, as it allows to rebuild the proper files when the source is updated, and helps avoid situations when we have a mix of old and new object files.
2. Remove only those files which we have generated. This will avoid the situations when we remove by accident a file (say, during the uninstall) which for some reason was put to the removed directory by the user or another program. I also removed the `-r` switch from `rm` command for that very reason: if the directory cannot be removed without `-r`, it is not empty, and then either our `clean` rule misses some files (it needs to be fixed then), or the user has put something to that directory.
3. Build directories now order-depend on the target `.o` files — that is, they will be created only when necessary, which saves a few calls to `mkdir -p`
4. Took out ``${PHP_CONFIG} --includes`` of the compiler flags and moved it to a variable. This results in slight performance improvement — now there is only one call to `${PHP_CONFIG} --includes` when the variable is evaluated (previously `php-config` would be invoked for every file being compiled)
5. Allow the user to override all the traditional variables via the command line (ie, `make CXX=clang++ CXXFLAGS="-O2 -g -Weverything"`) without having to edit the Makefile. These variables include: `CPPFLAGS` (preprocessor flags), `CXX` (C++ compiler), `CXXFLAGS` (custom flags passed to the C++ compiler), `LDFLAGS` (additional flags passed to the linker), `LDLIBS` (additional libraries passed to the linker). Compiler flags which are used internally (ie, `-fpic` etc) go to `variable_EXTRA`
6. Removed the "version part" from the static library: static libraries are `libsomething.a`, not `libsomething.a.1.0.0`
7. Changed soname version from 2.0 to 2. It is of course not forbidden to have a soname version with a dot, but I have never seen a library having such a soname (ie, `libc.so.6`, `libm.so.6`, `libpthread.so.0`). `libphpcpp.so.2.0.so` can be emulated with a symlink
8. `install` and `uninstall` targets now correctly handle custom names for `PHP_STATIC_LIBRARY` (correct symlinks are generated). Necessary symlinks are now generated via Makefile targets (ie, when necessary, not unconditionally)

## Dependency Generation

Basically it boils down to this fragment:
```Makefile
SOURCE_DEPS = $(patsubst %.o,%.d,$(OBJECTS))
ifeq (,$(findstring clean,$(MAKECMDGOALS)))
-include $(SOURCE_DEPS)
endif

clean: cleandeps
cleandeps:
        -$(RM) $(SOURCE_DEPS)
```
and passing `-MMD -MP -MF"$(@:%.o=%.d)" -MT"$@" -MT"$(@:%.o=%.d)"` flags to the compiler.

What this does is:
  * `-MMD` generates dependency output file but does not mention system headers (can be changed to `-MD` if system headers are desirable but `-MMD` generates a much smaller file)
  * `-MP` generates a phony target for each dependency other than the main file - in case a header file gets deleted
  * `-MF"$(@:%.o=%.d)"` sets the name of the dependency file (that will be the same file as the object one but with `.d` extension)
  * `-MT"$@"` sets the target name to the object file (that is, make `file.o` depend on all its sources)
  * `-MT"$(@:%.o=%.d)"` adds the `.d` file as an additional dependency. That is, `file.o file.d: file.c file.h`. This causes the `.d` file to be regenerated when one of the source file it depends on gets modified (ie, if you add a new `#include` to the file, the target `.o` should also depend on that `#include` therefore the corresponding `.d` needs to be regenerated).

## Build Directories
```Makefile
shared_directories: shared/common shared/zend
static_directories: static/common static/zend
shared/common shared/zend static/common static/zend:
        $(MKDIR) $@

static/%.o: %.cpp | static_directories
        $(CXX) ...

shared/%.o: %.cpp | shared_directories
        $(CXX) ...
```

# Cosmetic changes
1. Replaced inner tabs with spaces to make the file look nice for people with different tabulation size
2. `$(VARIABLE)` vs `${VARIABLE}` (makes it uniform with function calls)
