### PR TITLE
Add support for $(DESTDIR) in Makefile, in order to support Staged Installs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ UNAME 				:= 	$(shell uname)
 # Since OSX 10.10 Yosemite, /usr/include gives problem
 # So, let's switch to /usr/local as default instead.
 ifeq ($(UNAME), Darwin)
-  INSTALL_PREFIX		=	/usr/local
+  INSTALL_PREFIX		=	$(DESTDIR)/usr/local
 else
-  INSTALL_PREFIX		=	/usr
+  INSTALL_PREFIX		=	$(DESTDIR)/usr
 endif
 
 INSTALL_HEADERS			=	${INSTALL_PREFIX}/include
@@ -216,13 +216,13 @@ install:
 	${CP} include/*.h ${INSTALL_HEADERS}/phpcpp
 	if [ -e ${PHP_SHARED_LIBRARY} ]; then \
 		${CP} ${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/; \
-		${LN} ${INSTALL_LIB}/${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/libphpcpp.so.$(SONAME); \
-		${LN} ${INSTALL_LIB}/${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/libphpcpp.so; \
+		${LN} ${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/libphpcpp.so.$(SONAME); \
+		${LN} ${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/libphpcpp.so; \
 	fi
 	if [ -e ${PHP_STATIC_LIBRARY} ]; then ${CP} ${PHP_STATIC_LIBRARY} ${INSTALL_LIB}/; \
-		${LN} ${INSTALL_LIB}/${PHP_STATIC_LIBRARY} ${INSTALL_LIB}/libphpcpp.a; \
+		${LN} ${PHP_STATIC_LIBRARY} ${INSTALL_LIB}/libphpcpp.a; \
 	fi
-	if `which ldconfig`; then \
+	if `which ldconfig` && [ "$(DESTDIR)" == "" ]; then \
 		sudo ldconfig; \
 	fi
 


### PR DESCRIPTION
A minor refactoring to comply with the GNU Coding Standards: 7.2.4:
http://www.gnu.org/prep/standards/html_node/DESTDIR.html#DESTDIR

This is required, so that we can build Debian/Ubuntu .deb packages.

Usually, $(DESTDIR) is empty, and therefore, nothing really changes
in the current Makefile behavior.

I'll open another Pull Request for the real .deb packaging.