### PR TITLE
Added possibility to compile this library as a static or dynamic library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ endif
 #   you want to leave that flag out on production servers).
 #
 
-COMPILER_FLAGS			=	-Wall -c -std=c++11 -fvisibility=hidden -DBUILDING_PHPCPP -Wno-write-strings -MD
+COMPILER_FLAGS			=	-Wall -c -std=c++11 -fvisibility=hidden -DBUILDING_PHPCPP -DBUILDING_SHARED -Wno-write-strings -MD
 SHARED_COMPILER_FLAGS	=	-fpic
 STATIC_COMPILER_FLAGS	=
 PHP_COMPILER_FLAGS		=	${COMPILER_FLAGS} `${PHP_CONFIG} --includes`

--- a/include/streams.h
+++ b/include/streams.h
@@ -21,11 +21,11 @@ namespace Php {
 /**
  *  Define the out and err objects
  */
-extern thread_local PHPCPP_EXPORT std::ostream out;
-extern thread_local PHPCPP_EXPORT std::ostream error;
-extern thread_local PHPCPP_EXPORT std::ostream notice;
-extern thread_local PHPCPP_EXPORT std::ostream warning;
-extern thread_local PHPCPP_EXPORT std::ostream deprecated;
+extern thread_local std::ostream out;
+extern thread_local std::ostream error;
+extern thread_local std::ostream notice;
+extern thread_local std::ostream warning;
+extern thread_local std::ostream deprecated;
 
 /**
  *  End namespace

--- a/include/value.h
+++ b/include/value.h
@@ -1197,8 +1197,8 @@ protected:
     /**
      *  Functions that need access to the privates
      */
-    friend Value constant(const char *name, size_t size);
-    friend bool  define(const char *name, size_t size, const Value &value);
+    friend PHPCPP_EXPORT Value constant(const char *name, size_t size);
+    friend PHPCPP_EXPORT bool  define(const char *name, size_t size, const Value &value);
 
     /**
      *  The Globals and Member classes can access the zval directly
@@ -1220,8 +1220,8 @@ protected:
     /**
      *  Friend functions which have to access that zval directly
      */
-    friend Value set_exception_handler(const std::function<Value(Parameters &params)> &handler);
-    friend Value set_error_handler(const std::function<Value(Parameters &params)> &handler, Error error);
+    friend Value PHPCPP_EXPORT set_exception_handler(const std::function<Value(Parameters &params)> &handler);
+    friend Value PHPCPP_EXPORT set_error_handler(const std::function<Value(Parameters &params)> &handler, Error error);
 };
 
 /**

--- a/include/visibility.h
+++ b/include/visibility.h
@@ -13,18 +13,33 @@
 
 #if defined _WIN32 || defined __CYGWIN__
     #ifdef BUILDING_PHPCPP
-        #ifdef __GNUC__
-            #define PHPCPP_EXPORT __attribute__ ((dllexport))
-        #else
-            #define PHPCPP_EXPORT __declspec(dllexport) // Note: actually gcc seems to also supports this syntax.
+        #ifdef BUILDING_SHARED
+            #ifdef __GNUC__
+                #define PHPCPP_EXPORT __attribute__ ((dllexport))
+            #else
+                #define PHPCPP_EXPORT __declspec(dllexport) // Note: actually gcc seems to also supports this syntax.
+            #endif
+        #else /* build static library */
+          #define PHPCPP_EXPORT
         #endif
+        #define DLL_EXPORT
     #else
-        #ifdef __GNUC__
-            #define DLL_EXPORT __attribute__ ((dllimport))
-        #else
-            #define DLL_EXPORT __declspec(dllimport) // Note: actually gcc seems to also supports this syntax.
+        #ifdef BUILDING_SHARED
+            #ifdef __GNUC__
+                #define DLL_EXPORT __attribute__ ((dllimport))
+            #else
+                #define DLL_EXPORT __declspec(dllimport) // Note: actually gcc seems to also supports this syntax.
+            #endif
+        #else /* build static library */
+            #define DLL_EXPORT
         #endif
+        #define PHPCPP_EXPORT
     #endif
 #else
-    #define PHPCPP_EXPORT __attribute__ ((visibility ("default")))
+    #ifdef BUILDING_SHARED
+        #define PHPCPP_EXPORT __attribute__ ((visibility ("default")))
+    #else /* build static library */
+        #define PHPCPP_EXPORT
+    #endif
+    #define DLL_EXPORT
 #endif


### PR DESCRIPTION
- visibility.h/Makefile - Added possibility to compile this library as a static or dynamic library
- value.h - Fixed friend declarations because the must have also the PHPCPP_EXPORT declaration (C2375 redefinition; different linkage)
- streams.h - Fixed extern thread_local stream definition because the can't have PHPCPP_EXPORT declaration (C2492 'deprecated': data with thread storage duration may not have dll interface)