### PR TITLE
Always set php globals when being accessed

### DIFF
--- a/include/super.h
+++ b/include/super.h
@@ -28,7 +28,8 @@ public:
      *  @param  index   index number
      *  @param  name    name of the variable in PHP
      */
-    Super(int index, const char *name) : _index(index), _name(name) {}
+    template<size_t N>
+    Super(int index, const char(&name)[N]) : _index(index), _name(name), _length(N-1) {}
 
     /**
      *  Destructor
@@ -101,6 +102,12 @@ private:
      *  @var    name
      */
     const char *_name;
+
+    /**
+    *  Length of the variable in PHP
+    *  @var    name
+    */
+    size_t _length;
 
     /**
      *  Turn the object into a value object

--- a/zend/super.cpp
+++ b/zend/super.cpp
@@ -29,14 +29,8 @@ Super REQUEST   (TRACK_VARS_REQUEST, "_REQUEST");
  */
 Value Super::value()
 {
-    // call zend_is_auto_global to ensure that the just-in-time globals are loaded
-    if (_name) {
-        // make the variable an auto global
-        zend_is_auto_global(String{ _name });
-
-        // reset because we only need to do this once
-        _name = nullptr;
-    }
+    // make the variable an auto global
+    zend_is_auto_global_str((char*)_name, _length);
 
     // create a value object that wraps around the actual zval
     return &PG(http_globals)[_index];


### PR DESCRIPTION
This should be done because if Php module is used with threads the globals may or may not be set.