### PR TITLE
Fix GCC 10 missing include

### DIFF
--- a/include/throwable.h
+++ b/include/throwable.h
@@ -11,6 +11,7 @@
  */
 #include <exception>
 #include <string>
+#include <stdexcept>
 
 /**
  *  Forward declarations


### PR DESCRIPTION
libstdc++ changed inclusion of headers. As per https://gcc.gnu.org/legacy-ml/libstdc++/2019-06/msg00032.html 

Previously <stdexcept> was brought in as an implementation detail from headers included  in <memory>, <map> or <functional>. Since this no longer occurs we need to include <stdexcept>