### PR TITLE
Create FreeBSD-specific Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,11 @@ UNAME 				:= 	$(shell uname)
 ifeq ($(UNAME), Darwin)
   INSTALL_PREFIX		=	/usr/local
 else
+ifeq ($(UNAME), FreeBSD)
+  INSTALL_PREFIX		=	/usr/local
+else
   INSTALL_PREFIX		=	/usr
+endif
 endif
 
 INSTALL_HEADERS			=	${INSTALL_PREFIX}/include

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,11 @@ ifeq ($(UNAME), Darwin)
   INSTALL_PREFIX		=	/usr/local
 else
 ifeq ($(UNAME), FreeBSD)
+ifdef PREFIX
+  INSTALL_PREFIX		=	$(PREFIX)
+else
   INSTALL_PREFIX		=	/usr/local
+endif
 else
   INSTALL_PREFIX		=	/usr
 endif

--- a/Makefile
+++ b/Makefile
@@ -35,15 +35,7 @@ UNAME 				:= 	$(shell uname)
 ifeq ($(UNAME), Darwin)
   INSTALL_PREFIX		=	/usr/local
 else
-ifeq ($(UNAME), FreeBSD)
-ifdef PREFIX
-  INSTALL_PREFIX		=	$(PREFIX)
-else
-  INSTALL_PREFIX		=	/usr/local
-endif
-else
   INSTALL_PREFIX		=	/usr
-endif
 endif
 
 INSTALL_HEADERS			=	${INSTALL_PREFIX}/include

--- a/Makefile.FreeBSD
+++ b/Makefile.FreeBSD
@@ -1,0 +1,63 @@
+.PATH:		${.CURDIR}/common
+.PATH:		${.CURDIR}/zend
+
+SHLIB=		phpcpp
+SHLIB_MAJOR=	2.2.1
+MAN=
+
+# common
+SRCS=	modifiers.cpp
+
+# zend
+SRCS+=	base.cpp
+SRCS+=	callable.cpp
+SRCS+=	classbase.cpp
+SRCS+=	classimpl.cpp
+SRCS+=	constant.cpp
+SRCS+=	constantfuncs.cpp
+SRCS+=	error.cpp
+SRCS+=	eval.cpp
+SRCS+=	exception.cpp
+SRCS+=	exception_handler.cpp
+SRCS+=	exists.cpp
+SRCS+=	extension.cpp
+SRCS+=	extensionimpl.cpp
+SRCS+=	file.cpp
+SRCS+=	function.cpp
+SRCS+=	functor.cpp
+SRCS+=	global.cpp
+SRCS+=	globals.cpp
+SRCS+=	hashmember.cpp
+SRCS+=	ini.cpp
+SRCS+=	inivalue.cpp
+SRCS+=	iteratorimpl.cpp
+SRCS+=	members.cpp
+SRCS+=	module.cpp
+SRCS+=	namespace.cpp
+SRCS+=	object.cpp
+SRCS+=	sapi.cpp
+SRCS+=	script.cpp
+SRCS+=	stream.cpp
+SRCS+=	streambuf.cpp
+SRCS+=	streams.cpp
+SRCS+=	super.cpp
+SRCS+=	throwable.cpp
+SRCS+=	value.cpp
+SRCS+=	valueiterator.cpp
+SRCS+=	zendcallable.cpp
+SRCS+=	zval.cpp
+
+CFLAGS+=	-std=c++11 -DBUILDING_PHPCPP -MD -Wno-write-strings -fvisibility=hidden
+
+PHP_CONFIG=	php-config
+PHP_CFLAGS!=	${PHP_CONFIG} --includes
+PHP_LDFLAGS!=	${PHP_CONFIG} --ldflags
+CFLAGS+=	${PHP_CFLAGS}
+LDFLAGS+=	${PHP_LDFLAGS}
+
+.if defined(PREFIX)
+LIBDIR=		${PREFIX}/lib
+INCLUDEDIR=	${PREFIX}/include
+.endif
+
+.include <bsd.lib.mk>

--- a/obj/.gitignore
+++ b/obj/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This PR introduces a new `Makefile.FreeBSD` that is friendly with the bsdmake framework. This allows for easy integration into the FreeBSD ports tree.

Sponsored-by: BlackhawkNest, Inc