### PR TITLE
Improve performance of destructing objects

### DIFF
--- a/zend/base.cpp
+++ b/zend/base.cpp
@@ -17,9 +17,8 @@ namespace Php {
  */
 void Base::__destruct() const
 {
-    // throw exception, so that the PHP-CPP library will check if the user
-    // somehow registered an explicit __destruct method
-    throw NotImplemented();
+    // destroy the object by default
+    zend_objects_destroy_object(_impl->php());
 }
 
 /**

--- a/zend/classimpl.cpp
+++ b/zend/classimpl.cpp
@@ -1130,7 +1130,9 @@ void ClassImpl::destructObject(zend_object *object)
     }
     catch (const NotImplemented &exception)
     {
-        // fallback on the default destructor call
+        // fallback on the default destructor call in case a derived object
+        // of Base throws this. The default implementation will call this
+        // function in any case.
         zend_objects_destroy_object(object);
     }
     catch (Throwable &throwable)


### PR DESCRIPTION
We used to throw a NotImplemented exception, but this causes the c++ runtime
to allocate on the heap. We can call zend_objects_destroy_object directly
in the Php::Base::__destroy method instead.

If someone overrides this method, then zend_objects_destroy_object will not
be called, which is the behavior we had before as well.

See project 34296 for more details.