### PR TITLE
reorder PHP_VERSION_ID conditionals for consistency

### DIFF
--- a/common/modifiers.cpp
+++ b/common/modifiers.cpp
@@ -20,21 +20,21 @@ namespace Php {
 /**
  *  The modifiers are constants
  */
-#if PHP_VERSION_ID >= 70400
-const int Static    =   0x10;
-const int Abstract  =   0x40;
-const int Final     =   0x20;
-const int Public    =   0x01;
-const int Protected =   0x02;
-const int Private   =   0x04;
-const int Const     =   0;
-#else
+#if PHP_VERSION_ID < 70400
 const int Static    =   0x01;
 const int Abstract  =   0x02;
 const int Final     =   0x04;
 const int Public    =   0x100;
 const int Protected =   0x200;
 const int Private   =   0x400;
+const int Const     =   0;
+#else
+const int Static    =   0x10;
+const int Abstract  =   0x40;
+const int Final     =   0x20;
+const int Public    =   0x01;
+const int Protected =   0x02;
+const int Private   =   0x04;
 const int Const     =   0;
 #endif
 

--- a/zend/callable.cpp
+++ b/zend/callable.cpp
@@ -37,11 +37,11 @@ void Callable::invoke(INTERNAL_FUNCTION_PARAMETERS)
     // Sanity check
     assert(ZEND_TYPE_IS_SET(info[argc].type) && info[argc].name == nullptr);
     // the callable we are retrieving
-#if PHP_VERSION_ID < 80000
+# if PHP_VERSION_ID < 80000
     Callable *callable = reinterpret_cast<Callable*>(info[argc].type);
-#else
+# else
     Callable *callable = reinterpret_cast<Callable*>(info[argc].type.ptr);
-#endif
+# endif
 #endif
 
     // check if sufficient parameters were passed (for some reason this check
@@ -64,7 +64,7 @@ void Callable::invoke(INTERNAL_FUNCTION_PARAMETERS)
         {
             // get the result
             Value result(callable->invoke(params));
-            
+
             // return a full copy of the zval, and do not destruct it
             RETVAL_ZVAL(result._val, 1, 0);
         }

--- a/zend/classimpl.h
+++ b/zend/classimpl.h
@@ -13,17 +13,17 @@
  */
 namespace Php {
 
-#if PHP_VERSION_ID >= 70400
-#	define PHP_WRITE_PROP_HANDLER_TYPE zval *
+#if PHP_VERSION_ID < 70400
+# define PHP_WRITE_PROP_HANDLER_TYPE void
 #else
-#	define PHP_WRITE_PROP_HANDLER_TYPE void
+# define PHP_WRITE_PROP_HANDLER_TYPE zval *
 #endif
 #if PHP_VERSION_ID < 80000
-#define ZEND_OBJECT_OR_ZVAL zval *
-#define ZEND_STRING_OR_ZVAL zval *
+# define ZEND_OBJECT_OR_ZVAL zval *
+# define ZEND_STRING_OR_ZVAL zval *
 #else
-#define ZEND_OBJECT_OR_ZVAL zend_object *
-#define ZEND_STRING_OR_ZVAL zend_string *
+# define ZEND_OBJECT_OR_ZVAL zend_object *
+# define ZEND_STRING_OR_ZVAL zend_string *
 #endif
 /**
  *  Class definition
@@ -218,10 +218,10 @@ public:
      *  @param  count
      *  @return int
      */
-#if PHP_VERSION_ID >= 80200
-    static zend_result countElements(ZEND_OBJECT_OR_ZVAL object, zend_long *count);
-#else
+#if PHP_VERSION_ID < 80200
     static int countElements(ZEND_OBJECT_OR_ZVAL object, zend_long *count);
+#else
+    static zend_result countElements(ZEND_OBJECT_OR_ZVAL object, zend_long *count);
 #endif
     /**
      *  Function that is called when the object is used as an array in PHP
@@ -346,10 +346,10 @@ public:
      *  @param  type
      *  @return int
      */
-#if PHP_VERSION_ID >= 80200
-    static zend_result cast(ZEND_OBJECT_OR_ZVAL object, zval *retval, int type);
-#else
+#if PHP_VERSION_ID < 80200
     static int cast(ZEND_OBJECT_OR_ZVAL object, zval *retval, int type);
+#else
+    static zend_result cast(ZEND_OBJECT_OR_ZVAL object, zval *retval, int type);
 #endif
 
     /**

--- a/zend/file.cpp
+++ b/zend/file.cpp
@@ -28,9 +28,9 @@ namespace Php {
  */
 File::File(const char *name, size_t size) : _original(zend_string_init(name, size, 0))
 {
-#if PHP_VERSION_ID < 80000
+#if PHP_VERSION_ID < 80100
     // resolve the path
-    _path = zend_resolve_path(name, size);    
+    _path = zend_resolve_path(name, size);
 #else
     // first convert the path, then read it
     _path = zend_resolve_path(_original);
@@ -44,7 +44,7 @@ File::~File()
 {
     // clean up path name
     if (_path) zend_string_release(_path);
-    
+
     // clean up original path
     if (_original) zend_string_release(_original);
 }
@@ -64,7 +64,10 @@ bool File::compile()
     // we are going to open the file
     zend_file_handle fileHandle;
 
-#if PHP_VERSION_ID > 80000
+#if PHP_VERSION_ID < 80100
+    // open the file
+    if (zend_stream_open(ZSTR_VAL(_path), &fileHandle) == FAILURE) return false;
+#else
     /**
      *  zend_stream_open now only accepts the fileHandle object
      *  Filename must now be set through the object path.
@@ -73,9 +76,6 @@ bool File::compile()
 
     // open the file
     if (zend_stream_open(&fileHandle) == FAILURE) return false;
-#else
-    // open the file
-    if (zend_stream_open(ZSTR_VAL(_path), &fileHandle) == FAILURE) return false;   
 #endif
 
     // make sure the path name is stored in the handle (@todo: is this necessary? do we need the copy?)

--- a/zend/script.cpp
+++ b/zend/script.cpp
@@ -35,14 +35,14 @@ zend_op_array *Script::compile(const char *name, const char *phpcode, size_t siz
 
     // remember the old compiler options, and set new compiler options
     CompilerOptions options(ZEND_COMPILE_DEFAULT_FOR_EVAL);
-    
+
     // compile the string
 #if PHP_VERSION_ID < 80000
     return zend_compile_string(source._val, (char *)name);
-#elif PHP_VERSION_ID >= 80200
-    return zend_compile_string(zval_get_string(source._val), (char*)name, ZEND_COMPILE_POSITION_AT_OPEN_TAG);
-#else
+#elif PHP_VERSION_ID < 80200
     return zend_compile_string(zval_get_string(source._val), (char*)name);
+#else
+    return zend_compile_string(zval_get_string(source._val), (char*)name, ZEND_COMPILE_POSITION_AT_OPEN_TAG);
 #endif
 }
 
@@ -86,7 +86,7 @@ Value Script::execute() const
 {
     // pass on to opcodes
     if (!_opcodes) return nullptr;
-    
+
     // execute opcodes
     return _opcodes->execute();
 }

--- a/zend/value.cpp
+++ b/zend/value.cpp
@@ -163,7 +163,7 @@ Value::Value(struct _zval_struct *val, bool ref)
         // increment refcount
         ++GC_REFCOUNT(ref);
 #else
-	// increment refcount
+        // increment refcount
         GC_ADDREF(ref);
 #endif
         // store the reference in our value
@@ -315,7 +315,7 @@ Php::Zval Value::detach(bool keeprefcount)
 void Value::invalidate()
 {
     // do nothing if object is already undefined
-	if (Z_TYPE_P(_val) == IS_UNDEF) return;
+    if (Z_TYPE_P(_val) == IS_UNDEF) return;
 
     // call destructor
     zval_ptr_dtor(_val);
@@ -766,7 +766,7 @@ static Value do_exec(const zval *object, zval *method, int argc, zval *argv)
 
     // remember current state of the PHP engine
     State state;
-    
+
     // call the function
     // we're casting the const away here, object is only const so we can call this method
     // from const methods after all..
@@ -1514,11 +1514,11 @@ bool Value::contains(const char *key, int size) const
     }
     else if (isObject())
     {
-#if PHP_VERSION_ID >= 70400
         // retrieve the object pointer and check whether the property we are trying to retrieve
-        if (zend_check_property_access(Z_OBJ_P(_val), String(key, size), 0) == FAILURE) return false;
-#else
+#if PHP_VERSION_ID < 70400
         if (zend_check_property_access(Z_OBJ_P(_val), String(key, size)) == FAILURE) return false;
+#else
+        if (zend_check_property_access(Z_OBJ_P(_val), String(key, size), 0) == FAILURE) return false;
 #endif
         // check if the 'has_property' method is available for this object
         auto *has_property = Z_OBJ_HT_P(_val)->has_property;
@@ -1615,7 +1615,7 @@ Value Value::get(const char *key, int size) const
 #if PHP_VERSION_ID < 80000
         zval *property = zend_read_property(scope, _val, key, size, 0, &rv);
 #else
-        zend_object *zobj = Z_OBJ_P(_val); 
+        zend_object *zobj = Z_OBJ_P(_val);
         zval *property = zend_read_property(scope, zobj, key, size, 0, &rv);
 
 #endif


### PR DESCRIPTION
Reorder `#if`/`#else` blocks in order of oldest to most recent version of PHP.

In `zend/file.cpp`, compare `PHP_VERSION_ID` against `80100` as 27ad89e0 fixed changes relating to php 8.1 support (a5d90148)

In the touched files, also fixed whitespace inconsistencies (tabs and trailing spaces).