### PR TITLE
Php8 fix __get (by disabling void*->bool conversion)

### DIFF
--- a/include/class.h
+++ b/include/class.h
@@ -227,6 +227,7 @@ public:
     Class<T> &property(const char *name, const char *value,        int flags = Public) { ClassBase::property(name, value, flags); return *this; }
     Class<T> &property(const char *name, const std::string &value, int flags = Public) { ClassBase::property(name, value, flags); return *this; }
     Class<T> &property(const char *name, bool value,               int flags = Public) { ClassBase::property(name, value, flags); return *this; }
+    Class<T> &property(const char *name, const void *value,        int flags = Public) = delete;
     Class<T> &property(const char *name, double value,             int flags = Public) { ClassBase::property(name, value, flags); return *this; }
 
     /**

--- a/include/classbase.h
+++ b/include/classbase.h
@@ -273,6 +273,7 @@ protected:
     void property(const char *name, int32_t value, int flags = Php::Public);
     void property(const char *name, int64_t value, int flags = Php::Public);
     void property(const char *name, bool value, int flags = Php::Public);
+    void property(const char *name, const void *value, int flags = Php::Public) = delete;
     void property(const char *name, char value, int flags = Php::Public);
     void property(const char *name, const std::string &value, int flags = Php::Public);
     void property(const char *name, const char *value, int flags = Php::Public);

--- a/include/constant.h
+++ b/include/constant.h
@@ -44,6 +44,7 @@ public:
      * @param value Constant's value
      */
     Constant(const char *name, bool value);
+    Constant(const char *name, const void *value) = delete;
 
     /**
      * Constructor to create a constant for a 32-bit integer

--- a/include/hashmember.h
+++ b/include/hashmember.h
@@ -191,6 +191,7 @@ public:
     HashMember &operator+=(int32_t value)               { return operator=(this->value() + value); }
     HashMember &operator+=(int64_t value)               { return operator=(this->value() + value); }
     HashMember &operator+=(bool value)                  { return operator=(this->value() + value); }
+    HashMember &operator+=(const void *value)           = delete;
     HashMember &operator+=(char value)                  { return operator=(this->value() + value); }
     HashMember &operator+=(const std::string &value)    { return operator=(this->value() + value); }
     HashMember &operator+=(const char *value)           { return operator=(this->value() + value); }
@@ -206,6 +207,7 @@ public:
     HashMember &operator-=(int32_t value)               { return operator=(this->value() - value); }
     HashMember &operator-=(int64_t value)               { return operator=(this->value() - value); }
     HashMember &operator-=(bool value)                  { return operator=(this->value() - value); }
+    HashMember &operator-=(const void *value)           = delete;
     HashMember &operator-=(char value)                  { return operator=(this->value() - value); }
     HashMember &operator-=(const std::string &value)    { return operator=(this->value() - value); }
     HashMember &operator-=(const char *value)           { return operator=(this->value() - value); }
@@ -221,6 +223,7 @@ public:
     HashMember &operator*=(int32_t value)               { return operator=(this->value() * value); }
     HashMember &operator*=(int64_t value)               { return operator=(this->value() * value); }
     HashMember &operator*=(bool value)                  { return operator=(this->value() * value); }
+    HashMember &operator*=(const void *value)           = delete;
     HashMember &operator*=(char value)                  { return operator=(this->value() * value); }
     HashMember &operator*=(const std::string &value)    { return operator=(this->value() * value); }
     HashMember &operator*=(const char *value)           { return operator=(this->value() * value); }
@@ -236,6 +239,7 @@ public:
     HashMember &operator/=(int32_t value)               { return operator=(this->value() / value); }
     HashMember &operator/=(int64_t value)               { return operator=(this->value() / value); }
     HashMember &operator/=(bool value)                  { return operator=(this->value() / value); }
+    HashMember &operator/=(const void *value)           = delete;
     HashMember &operator/=(char value)                  { return operator=(this->value() / value); }
     HashMember &operator/=(const std::string &value)    { return operator=(this->value() / value); }
     HashMember &operator/=(const char *value)           { return operator=(this->value() / value); }
@@ -251,6 +255,7 @@ public:
     HashMember &operator%=(int32_t value)               { return operator=(this->value() % value); }
     HashMember &operator%=(int64_t value)               { return operator=(this->value() % value); }
     HashMember &operator%=(bool value)                  { return operator=(this->value() % value); }
+    HashMember &operator%=(const void *value)           = delete;
     HashMember &operator%=(char value)                  { return operator=(this->value() % value); }
     HashMember &operator%=(const std::string &value)    { return operator=(this->value() % value); }
     HashMember &operator%=(const char *value)           { return operator=(this->value() % value); }
@@ -266,6 +271,7 @@ public:
     Value operator+(int32_t value)              { return this->value() + value; }
     Value operator+(int64_t value)              { return this->value() + value; }
     Value operator+(bool value)                 { return this->value() + value; }
+    Value operator+(const void *value)          = delete;
     Value operator+(char value)                 { return this->value() + value; }
     Value operator+(const std::string &value)   { return this->value() + value; }
     Value operator+(const char *value)          { return this->value() + value; }
@@ -281,6 +287,7 @@ public:
     Value operator-(int32_t value)              { return this->value() - value; }
     Value operator-(int64_t value)              { return this->value() - value; }
     Value operator-(bool value)                 { return this->value() - value; }
+    Value operator-(const void *value)          = delete;
     Value operator-(char value)                 { return this->value() - value; }
     Value operator-(const std::string &value)   { return this->value() - value; }
     Value operator-(const char *value)          { return this->value() - value; }
@@ -296,6 +303,7 @@ public:
     Value operator*(int32_t value)              { return this->value() * value; }
     Value operator*(int64_t value)              { return this->value() * value; }
     Value operator*(bool value)                 { return this->value() * value; }
+    Value operator*(const void *value)          = delete;
     Value operator*(char value)                 { return this->value() * value; }
     Value operator*(const std::string &value)   { return this->value() * value; }
     Value operator*(const char *value)          { return this->value() * value; }
@@ -311,6 +319,7 @@ public:
     Value operator/(int32_t value)              { return this->value() / value; }
     Value operator/(int64_t value)              { return this->value() / value; }
     Value operator/(bool value)                 { return this->value() / value; }
+    Value operator/(const void *value)          = delete;
     Value operator/(char value)                 { return this->value() / value; }
     Value operator/(const std::string &value)   { return this->value() / value; }
     Value operator/(const char *value)          { return this->value() / value; }
@@ -326,6 +335,7 @@ public:
     Value operator%(int32_t value)              { return this->value() % value; }
     Value operator%(int64_t value)              { return this->value() % value; }
     Value operator%(bool value)                 { return this->value() % value; }
+    Value operator%(const void *value)          = delete;
     Value operator%(char value)                 { return this->value() % value; }
     Value operator%(const std::string &value)   { return this->value() % value; }
     Value operator%(const char *value)          { return this->value() % value; }

--- a/include/ini.h
+++ b/include/ini.h
@@ -61,6 +61,7 @@ public:
      */
     Ini(const char *name, bool value, const Place place = Place::All) :
         _name(name), _value(bool2str(value)), _place(place) {}
+    Ini(const char *name, const void *value, const Place place = Place::All) = delete;
 
     /**
      *  Constructors for integer values

--- a/include/value.h
+++ b/include/value.h
@@ -60,6 +60,7 @@ public:
     Value(char value);
     Value(const std::string &value);
     Value(const char *value, int size = -1);
+    Value(struct _zend_string *value);
     Value(double value);
     Value(const IniValue &value);
 

--- a/include/value.h
+++ b/include/value.h
@@ -56,6 +56,7 @@ public:
     Value(int32_t value);
     Value(int64_t value);
     Value(bool value);
+    Value(const void *value) = delete;
     Value(char value);
     Value(const std::string &value);
     Value(const char *value, int size = -1);
@@ -174,6 +175,7 @@ public:
     Value &operator=(int32_t value);
     Value &operator=(int64_t value);
     Value &operator=(bool value);
+    Value &operator=(const void *value) = delete;
     Value &operator=(char value);
     Value &operator=(const std::string &value);
     Value &operator=(const char *value);
@@ -191,6 +193,7 @@ public:
     Value &operator+=(int32_t value);
     Value &operator+=(int64_t value);
     Value &operator+=(bool value);
+    Value &operator+=(const void *value) = delete;
     Value &operator+=(char value);
     Value &operator+=(const std::string &value);
     Value &operator+=(const char *value);
@@ -206,6 +209,7 @@ public:
     Value &operator-=(int32_t value);
     Value &operator-=(int64_t value);
     Value &operator-=(bool value);
+    Value &operator-=(const void *value) = delete;
     Value &operator-=(char value);
     Value &operator-=(const std::string &value);
     Value &operator-=(const char *value);
@@ -221,6 +225,7 @@ public:
     Value &operator*=(int32_t value);
     Value &operator*=(int64_t value);
     Value &operator*=(bool value);
+    Value &operator*=(const void *value) = delete;
     Value &operator*=(char value);
     Value &operator*=(const std::string &value);
     Value &operator*=(const char *value);
@@ -236,6 +241,7 @@ public:
     Value &operator/=(int32_t value);
     Value &operator/=(int64_t value);
     Value &operator/=(bool value);
+    Value &operator/=(const void *value) = delete;
     Value &operator/=(char value);
     Value &operator/=(const std::string &value);
     Value &operator/=(const char *value);
@@ -251,6 +257,7 @@ public:
     Value &operator%=(int32_t value);
     Value &operator%=(int64_t value);
     Value &operator%=(bool value);
+    Value &operator%=(const void *value) = delete;
     Value &operator%=(char value);
     Value &operator%=(const std::string &value);
     Value &operator%=(const char *value);
@@ -266,6 +273,7 @@ public:
     Value operator+(int32_t value);
     Value operator+(int64_t value);
     Value operator+(bool value);
+    Value operator+(const void *value) = delete;
     Value operator+(char value);
     Value operator+(const std::string &value);
     Value operator+(const char *value);
@@ -281,6 +289,7 @@ public:
     Value operator-(int32_t value);
     Value operator-(int64_t value);
     Value operator-(bool value);
+    Value operator-(const void *value) = delete;
     Value operator-(char value);
     Value operator-(const std::string &value);
     Value operator-(const char *value);
@@ -296,6 +305,7 @@ public:
     Value operator*(int32_t value);
     Value operator*(int64_t value);
     Value operator*(bool value);
+    Value operator*(const void *value) = delete;
     Value operator*(char value);
     Value operator*(const std::string &value);
     Value operator*(const char *value);
@@ -311,6 +321,7 @@ public:
     Value operator/(int32_t value);
     Value operator/(int64_t value);
     Value operator/(bool value);
+    Value operator/(const void *value) = delete;
     Value operator/(char value);
     Value operator/(const std::string &value);
     Value operator/(const char *value);
@@ -326,6 +337,7 @@ public:
     Value operator%(int32_t value);
     Value operator%(int64_t value);
     Value operator%(bool value);
+    Value operator%(const void *value) = delete;
     Value operator%(char value);
     Value operator%(const std::string &value);
     Value operator%(const char *value);
@@ -333,6 +345,10 @@ public:
 
     /**
      *  Comparison operators for hardcoded strings
+     *
+     *  Note that this works only for string values,
+     *  other values segfaults!
+     *
      *  @param  value
      */
     bool operator==(const char *value) const { return ::strcmp(rawValue(), value) == 0; }

--- a/zend/value.cpp
+++ b/zend/value.cpp
@@ -129,6 +129,25 @@ Value::Value(const char *value, int size)
 }
 
 /**
+ *  Constructor based on zend_string
+ *  @param  value
+ */
+Value::Value(struct _zend_string *value)
+{
+    // is there a value?
+    if (value)
+    {
+        // create a string zval
+        ZVAL_STRINGL(_val, value->val, value->len);
+    }
+    else
+    {
+        // store null
+        ZVAL_NULL(_val);
+    }
+}
+
+/**
  *  Constructor based on decimal value
  *  @param  value
  */


### PR DESCRIPTION
Magic methods (__get and others) lead to segfaults, because of mishandling `struct _zend_string *` arguments that came with PHP8.
Thus methods accepting bool values need deleted void * counterparts. After this is done, constructror of `Php::Value(struct _zend_string *)` is added so that __get and others work the same way in PHP8 as they were working in PHP7.