### PR TITLE
Build multiple php versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,10 @@ VERSION					=	2.4.3
 #   you can change that here.
 #
 
-PHP_SHARED_LIBRARY		=	libphpcpp.so.$(VERSION)
-PHP_STATIC_LIBRARY		=	libphpcpp.a.$(VERSION)
+LIBRARY_NAME			=	libphpcpp
+
+PHP_SHARED_LIBRARY		=	${LIBRARY_NAME}.so.$(VERSION)
+PHP_STATIC_LIBRARY		=	${LIBRARY_NAME}.a.$(VERSION)
 
 
 #
@@ -200,7 +202,7 @@ phpcpp: ${BUILD_DIR}/${PHP_SHARED_LIBRARY} ${BUILD_DIR}/${PHP_STATIC_LIBRARY}
 	@echo "Build complete."
 
 ${BUILD_DIR}/${PHP_SHARED_LIBRARY}: build_directories ${COMMON_OBJECTS} ${PHP_OBJECTS}
-	${LINKER} ${PHP_LINKER_FLAGS} -Wl,${LINKER_SONAME_OPTION},libphpcpp.so.$(SONAME) -o $@ ${COMMON_OBJECTS} ${PHP_OBJECTS}
+	${LINKER} ${PHP_LINKER_FLAGS} -Wl,${LINKER_SONAME_OPTION},${LIBRARY_NAME}.so.$(SONAME) -o $@ ${COMMON_OBJECTS} ${PHP_OBJECTS}
 
 ${BUILD_DIR}/${PHP_STATIC_LIBRARY}: build_directories ${COMMON_OBJECTS} ${PHP_OBJECTS}
 	${ARCHIVER} $@ ${COMMON_OBJECTS} ${PHP_OBJECTS}
@@ -230,16 +232,16 @@ install:
 	${CP} include/*.h ${INSTALL_HEADERS}/phpcpp
 	if [ -e ${BUILD_DIR}/${PHP_SHARED_LIBRARY} ]; then \
 		${CP} ${BUILD_DIR}/${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/ && \
-		${LN} ${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/libphpcpp.so.$(SONAME) && \
-		${LN} ${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/libphpcpp.so; \
+		${LN} ${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/${LIBRARY_NAME}.so.$(SONAME) && \
+		${LN} ${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/${LIBRARY_NAME}.so; \
 	fi
 	if [ -e ${BUILD_DIR}/${PHP_STATIC_LIBRARY} ]; then \
 		${CP} ${BUILD_DIR}/${PHP_STATIC_LIBRARY} ${INSTALL_LIB}/ && \
-		${LN} ${PHP_STATIC_LIBRARY} ${INSTALL_LIB}/libphpcpp.a; \
+		${LN} ${PHP_STATIC_LIBRARY} ${INSTALL_LIB}/${LIBRARY_NAME}.a; \
 	fi
 	${LDCONFIG}
 
 uninstall:
 	${RM} ${INSTALL_HEADERS}/phpcpp*
-	${RM} ${INSTALL_LIB}/libphpcpp.*
+	${RM} ${INSTALL_LIB}/${LIBRARY_NAME}.*
 

--- a/Makefile
+++ b/Makefile
@@ -220,13 +220,13 @@ install:
 	${MKDIR} ${INSTALL_LIB}
 	${CP} phpcpp.h ${INSTALL_HEADERS}
 	${CP} include/*.h ${INSTALL_HEADERS}/phpcpp
-	if [ -e ${BUILD_DIR}${PHP_SHARED_LIBRARY} ]; then \
-		${CP} ${BUILD_DIR}}/${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/; \
-		${LN} ${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/libphpcpp.so.$(SONAME); \
+	if [ -e ${BUILD_DIR}/${PHP_SHARED_LIBRARY} ]; then \
+		${CP} ${BUILD_DIR}/${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/ && \
+		${LN} ${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/libphpcpp.so.$(SONAME) && \
 		${LN} ${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/libphpcpp.so; \
 	fi
-	if [ -e ${BUILD_DIR}${PHP_STATIC_LIBRARY} ]; then \
-		${CP} ${BUILD_DIR}/${PHP_STATIC_LIBRARY} ${INSTALL_LIB}/; \
+	if [ -e ${BUILD_DIR}/${PHP_STATIC_LIBRARY} ]; then \
+		${CP} ${BUILD_DIR}/${PHP_STATIC_LIBRARY} ${INSTALL_LIB}/ && \
 		${LN} ${PHP_STATIC_LIBRARY} ${INSTALL_LIB}/libphpcpp.a; \
 	fi
 	if `which ldconfig`; then \

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,14 @@ BUILD_DIR			=	build
 UNAME 				:= 	$(shell uname)
 
 #
+#   If you do not want to run LDCONFIG, then set LDCONFIG to empty string.
+#   alternatively you can provide another command to register libraries
+#   after installation.
+#
+
+LDCONFIG	=	$(shell which ldconfig 2>/dev/null)
+
+#
 #   Installation directory
 #
 #   When you install the PHP-CPP library, it will place a number of C++ *.h
@@ -229,9 +237,7 @@ install:
 		${CP} ${BUILD_DIR}/${PHP_STATIC_LIBRARY} ${INSTALL_LIB}/ && \
 		${LN} ${PHP_STATIC_LIBRARY} ${INSTALL_LIB}/libphpcpp.a; \
 	fi
-	if `which ldconfig`; then \
-		ldconfig; \
-	fi
+	${LDCONFIG}
 
 uninstall:
 	${RM} ${INSTALL_HEADERS}/phpcpp*

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,14 @@
 #   libraries and the path to the binary file. If your php-config is not
 #   installed in the default directory, you can change that here.
 #
+#   If you use environment with multiple PHP versions (e.g. debian), you need
+#   to specify name or path of php-config utility that matches targeted php
+#   version. If you want to build for multiple PHP versions, then also consider
+#   changing BUILD_DIR variable, so that builds for each version are separated
+#
 
 PHP_CONFIG			=	php-config
+BUILD_DIR			=	build
 UNAME 				:= 	$(shell uname)
 
 #
@@ -157,14 +163,14 @@ PHP_SOURCES				=	$(wildcard zend/*.cpp)
 #   library. We also use a Makefile function here that takes all source files.
 #
 
-COMMON_OBJECTS	=	$(COMMON_SOURCES:%.cpp=build/%.o)
-PHP_OBJECTS		=	$(PHP_SOURCES:%.cpp=build/%.o)
+COMMON_OBJECTS	=	$(COMMON_SOURCES:%.cpp=${BUILD_DIR}/%.o)
+PHP_OBJECTS		=	$(PHP_SOURCES:%.cpp=${BUILD_DIR}/%.o)
 
 #
 #   Dependencies
 #
 
-DEPENDENCIES            =   $(wildcard build/common/*.d) $(wildcard build/zend/*.d)
+DEPENDENCIES            =   $(wildcard ${BUILD_DIR}/common/*.d) $(wildcard ${BUILD_DIR}/zend/*.d)
 
 #
 #   End of the variables section. Here starts the list of instructions and
@@ -181,30 +187,30 @@ release: COMPILER_FLAGS +=	-O2
 release: LINKER_FLAGS	+=  -O2
 release: phpcpp
 
-phpcpp: ${PHP_SHARED_LIBRARY} ${PHP_STATIC_LIBRARY}
+phpcpp: ${BUILD_DIR}/${PHP_SHARED_LIBRARY} ${BUILD_DIR}/${PHP_STATIC_LIBRARY}
 	@echo
 	@echo "Build complete."
 
-${PHP_SHARED_LIBRARY}: build_directories ${COMMON_OBJECTS} ${PHP_OBJECTS}
+${BUILD_DIR}/${PHP_SHARED_LIBRARY}: build_directories ${COMMON_OBJECTS} ${PHP_OBJECTS}
 	${LINKER} ${PHP_LINKER_FLAGS} -Wl,${LINKER_SONAME_OPTION},libphpcpp.so.$(SONAME) -o $@ ${COMMON_OBJECTS} ${PHP_OBJECTS}
 
-${PHP_STATIC_LIBRARY}: build_directories ${COMMON_OBJECTS} ${PHP_OBJECTS}
+${BUILD_DIR}/${PHP_STATIC_LIBRARY}: build_directories ${COMMON_OBJECTS} ${PHP_OBJECTS}
 	${ARCHIVER} $@ ${COMMON_OBJECTS} ${PHP_OBJECTS}
 
 build_directories:
-	${MKDIR} build/common
-	${MKDIR} build/zend
+	${MKDIR} ${BUILD_DIR}/common
+	${MKDIR} ${BUILD_DIR}/zend
 
 clean:
-	${RM} build ${PHP_SHARED_LIBRARY} ${PHP_STATIC_LIBRARY}
+	${RM} ${BUILD_DIR}
 	find -name *.o | xargs ${RM}
 	find -name *.d | xargs ${RM}
 
 ${COMMON_OBJECTS}:
-	${COMPILER} ${COMPILER_FLAGS} -o $@ ${@:build/%.o=%.cpp}
+	${COMPILER} ${COMPILER_FLAGS} -o $@ ${@:${BUILD_DIR}/%.o=%.cpp}
 
 ${PHP_OBJECTS}:
-	${COMPILER} ${COMPILER_FLAGS} -o $@ ${@:build/%.o=%.cpp}
+	${COMPILER} ${COMPILER_FLAGS} -o $@ ${@:${BUILD_DIR}/%.o=%.cpp}
 
 
 # The if statements below must be seen as single line by make
@@ -214,12 +220,13 @@ install:
 	${MKDIR} ${INSTALL_LIB}
 	${CP} phpcpp.h ${INSTALL_HEADERS}
 	${CP} include/*.h ${INSTALL_HEADERS}/phpcpp
-	if [ -e ${PHP_SHARED_LIBRARY} ]; then \
-		${CP} ${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/; \
+	if [ -e ${BUILD_DIR}${PHP_SHARED_LIBRARY} ]; then \
+		${CP} ${BUILD_DIR}}/${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/; \
 		${LN} ${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/libphpcpp.so.$(SONAME); \
 		${LN} ${PHP_SHARED_LIBRARY} ${INSTALL_LIB}/libphpcpp.so; \
 	fi
-	if [ -e ${PHP_STATIC_LIBRARY} ]; then ${CP} ${PHP_STATIC_LIBRARY} ${INSTALL_LIB}/; \
+	if [ -e ${BUILD_DIR}${PHP_STATIC_LIBRARY} ]; then \
+		${CP} ${BUILD_DIR}/${PHP_STATIC_LIBRARY} ${INSTALL_LIB}/; \
 		${LN} ${PHP_STATIC_LIBRARY} ${INSTALL_LIB}/libphpcpp.a; \
 	fi
 	if `which ldconfig`; then \


### PR DESCRIPTION
There can be multiple PHP versions installed at once on Debian Linux distributions. PHP maintainer for debian has repositories for this hosted on deb.sury.org. User needs to copy PHP-CPP source to be able to build phpcpp for multiple
php versions at once. Moreover they need patch soname of output .so, so that multiple versions can be used simultaneously.

This merge requests aims to fix that, by introducing Makefile variables:

* `LIBRARY_NAME` (default `libphpcpp`
* `BUILD_DIR` (default `build`)
* `LDCONFIG` (default `$(shell which ldconfig 2>/dev/null)`)

This change is backward compatible, i.e., behaviour of Makefile does not change when user user uses default values, with one exception: resulting .so and .a are now stored in root of `$(BUILD_DIR)` instead of root of project, so that multiple versions can be built at once, even if user wants them to have same name.

Excerpt from my makefile, that wraps PHP-CPP makefile for building for multiple PHP versions,
main line is the MAKEPHPCPP variable which expects PHP version in $* and expands to
call to PHP-CPP Makefile with properly set build variables.
```
all: $(addprefix do-all-, $(PHP_VERSIONS))
install: $(addprefix install-all-,$(PHP_VERSIONS))

PHP_CONFIG=php-config$*
DEBDEV=debian/phpcpp-php$*-dev
DEBLIB=debian/libphpcpp-php$*
#Relative to DEBDEV
DEBLIB_REL=../../$(DEBLIB)

MAKEPHPCPP=$(MAKE) -C PHP-CPP BUILD_DIR=build-$* PHP_CONFIG='$(PHP_CONFIG)' LIBRARY_NAME='libphpcpp$*'

call-all-%:
        $(MAKEPHPCPP)

do-all-%: call-all-%
        true

call-install-%:
        $(MAKEPHPCPP) install \
                LDCONFIG="" \
                INSTALL_LIB="../$(DEBDEV)/usr/lib/$(DEB_HOST_GNU_TYPE)/" \
                INSTALL_HEADERS="../$(DEBDEV)/`$(PHP_CONFIG) --include-dir`" \
                CP="cp -af"

do-install-%: call-install-%
        mkdir -p '$(DEBLIB)/usr/lib/$(DEB_HOST_GNU_TYPE)'
        set -e; cd '$(DEBDEV)'; \
        for F in 'usr/lib/$(DEB_HOST_GNU_TYPE)/libphpcpp$*.so.'*; do mv "$$F" '$(DEBLIB_REL)/'"$$F"; done
        mkdir -p '$(DEBDEV)/usr/share/pkgconfig/'
        sh phpcpp.pc.in $* > '$(DEBDEV)/usr/share/pkgconfig/phpcpp-php$*.pc'

```