### PR TITLE
Patch Makefiles to determine install locations automatically

### DIFF
--- a/Examples/CallPhpFunctions/Makefile
+++ b/Examples/CallPhpFunctions/Makefile
@@ -1,11 +1,9 @@
 CPP             = g++
 RM              = rm -f
 CPP_FLAGS       = -Wall -c -I. -O2 -std=c++11
-
-PREFIX			= /usr
-#Edit these lines to correspond with your own directories
+PHP_CONFIG      = $(shell which php-config)
 LIBRARY_DIR		= $(shell ${PHP_CONFIG} --extension-dir)
-PHP_CONFIG_DIR	= /etc/php5/cli/conf.d
+PHP_CONFIG_DIR	= $(shell ${PHP_CONFIG} --ini-dir)
 
 LD              = g++
 LD_FLAGS        = -Wall -shared -O2 
@@ -28,5 +26,9 @@ ${OBJECTS}:
 		${CPP} ${CPP_FLAGS} -fpic -o $@ ${@:%.o=%.cpp}
 
 install:
-		cp -f ${RESULT} ${LIBRARY_DIR}
-		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}
+		cp -f ${RESULT} ${LIBRARY_DIR}/
+		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}/
+
+uninstall:
+		rm ${LIBRARY_DIR}/${RESULT}
+		rm ${PHP_CONFIG_DIR}/${PHPINIFILE}

--- a/Examples/ConstStaticProp/cpp/Makefile
+++ b/Examples/ConstStaticProp/cpp/Makefile
@@ -2,10 +2,9 @@ CPP             = g++
 RM              = rm -f
 CPP_FLAGS       = -Wall -c -I. -O2 -std=c++11
 
-PREFIX			= /usr
-#Edit these lines to correspond with your own directories
+PHP_CONFIG      = $(shell which php-config)
 LIBRARY_DIR		= $(shell ${PHP_CONFIG} --extension-dir)
-PHP_CONFIG_DIR	= /etc/php5/cli/conf.d
+PHP_CONFIG_DIR	= $(shell ${PHP_CONFIG} --ini-dir)
 
 LD              = g++
 LD_FLAGS        = -Wall -shared -O2 
@@ -28,5 +27,9 @@ ${OBJECTS}:
 		${CPP} ${CPP_FLAGS} -fpic -o $@ ${@:%.o=%.cpp}
 
 install:
-		cp -f ${RESULT} ${LIBRARY_DIR}
-		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}
+		cp -f ${RESULT} ${LIBRARY_DIR}/
+		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}/
+
+uninstall:
+		rm ${LIBRARY_DIR}/${RESULT}
+		rm ${PHP_CONFIG_DIR}/${PHPINIFILE}

--- a/Examples/CppClassesInPhp/Makefile
+++ b/Examples/CppClassesInPhp/Makefile
@@ -29,7 +29,7 @@ NAME				=	cppclassinphp
 #	one for each extension. Use this variable to specify this directory.
 #
 
-INI_DIR				=	/etc/php5/conf.d
+INI_DIR				=	$(shell php-config --ini-dir)
 
 
 #

--- a/Examples/DlUnrestricted/Makefile
+++ b/Examples/DlUnrestricted/Makefile
@@ -29,7 +29,7 @@ NAME				=	dlunrestricted
 #	one for each extension. Use this variable to specify this directory.
 #
 
-INI_DIR				=	/etc/php5/mods-available
+INI_DIR				=	$(shell php-config --ini-dir)
 
 
 #

--- a/Examples/EmptyExtension/Makefile
+++ b/Examples/EmptyExtension/Makefile
@@ -29,7 +29,7 @@ NAME				=	yourextension
 #	one for each extension. Use this variable to specify this directory.
 #
 
-INI_DIR				=	/etc/php5/mods-available/
+INI_DIR				=	$(shell php-config --ini-dir)
 
 
 #

--- a/Examples/Exceptions/ExceptionCatch/Makefile
+++ b/Examples/Exceptions/ExceptionCatch/Makefile
@@ -2,10 +2,9 @@ CPP             = g++
 RM              = rm -f
 CPP_FLAGS       = -Wall -c -I. -O2 -std=c++11
 
-PREFIX			= /usr
-#Edit these lines to correspond with your own directories
+PHP_CONFIG      = $(shell which php-config)
 LIBRARY_DIR		= $(shell ${PHP_CONFIG} --extension-dir)
-PHP_CONFIG_DIR	= /etc/php5/cli/conf.d
+PHP_CONFIG_DIR	= $(shell ${PHP_CONFIG} --ini-dir)
 
 LD              = g++
 LD_FLAGS        = -Wall -shared -O2 
@@ -28,5 +27,9 @@ ${OBJECTS}:
 		${CPP} ${CPP_FLAGS} -fpic -o $@ ${@:%.o=%.cpp}
 
 install:
-		cp -f ${RESULT} ${LIBRARY_DIR}
-		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}
+		cp -f ${RESULT} ${LIBRARY_DIR}/
+		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}/
+
+uninstall:
+		rm ${LIBRARY_DIR}/${RESULT}
+		rm ${PHP_CONFIG_DIR}/${PHPINIFILE}

--- a/Examples/Exceptions/ExceptionThrow/Makefile
+++ b/Examples/Exceptions/ExceptionThrow/Makefile
@@ -2,10 +2,9 @@ CPP             = g++
 RM              = rm -f
 CPP_FLAGS       = -Wall -c -I. -O2 -std=c++11
 
-PREFIX			= /usr
-#Edit these lines to correspond with your own directories
+PHP_CONFIG      = $(shell which php-config)
 LIBRARY_DIR		= $(shell ${PHP_CONFIG} --extension-dir)
-PHP_CONFIG_DIR	= /etc/php5/cli/conf.d
+PHP_CONFIG_DIR	= $(shell ${PHP_CONFIG} --ini-dir)
 
 LD              = g++
 LD_FLAGS        = -Wall -shared -O2 
@@ -28,5 +27,9 @@ ${OBJECTS}:
 		${CPP} ${CPP_FLAGS} -fpic -o $@ ${@:%.o=%.cpp}
 
 install:
-		cp -f ${RESULT} ${LIBRARY_DIR}
-		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}
+		cp -f ${RESULT} ${LIBRARY_DIR}/
+		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}/
+
+uninstall:
+		rm ${LIBRARY_DIR}/${RESULT}
+		rm ${PHP_CONFIG_DIR}/${PHPINIFILE}

--- a/Examples/Extension/Makefile
+++ b/Examples/Extension/Makefile
@@ -2,10 +2,9 @@ CPP             = g++
 RM              = rm -f
 CPP_FLAGS       = -Wall -c -I. -O2 -std=c++11
 
-PREFIX			= /usr
-#Edit these lines to correspond with your own directories
+PHP_CONFIG      = $(shell which php-config)
 LIBRARY_DIR		= $(shell ${PHP_CONFIG} --extension-dir)
-PHP_CONFIG_DIR	= /etc/php5/cli/conf.d
+PHP_CONFIG_DIR	= $(shell ${PHP_CONFIG} --ini-dir)
 
 LD              = g++
 LD_FLAGS        = -Wall -shared -O2 
@@ -28,5 +27,9 @@ ${OBJECTS}:
 		${CPP} ${CPP_FLAGS} -fpic -o $@ ${@:%.o=%.cpp}
 
 install:
-		cp -f ${RESULT} ${LIBRARY_DIR}
-		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}
+		cp -f ${RESULT} ${LIBRARY_DIR}/
+		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}/
+
+uninstall:
+		rm ${LIBRARY_DIR}/${RESULT}
+		rm ${PHP_CONFIG_DIR}/${PHPINIFILE}

--- a/Examples/FunctionNoParameters/Makefile
+++ b/Examples/FunctionNoParameters/Makefile
@@ -2,10 +2,9 @@ CPP             = g++
 RM              = rm -f
 CPP_FLAGS       = -Wall -c -I. -O2 -std=c++11
 
-PREFIX			= /usr
-#Edit these lines to correspond with your own directories
+PHP_CONFIG      = $(shell which php-config)
 LIBRARY_DIR		= $(shell ${PHP_CONFIG} --extension-dir)
-PHP_CONFIG_DIR	= /etc/php5/cli/conf.d
+PHP_CONFIG_DIR	= $(shell ${PHP_CONFIG} --ini-dir)
 
 LD              = g++
 LD_FLAGS        = -Wall -shared -O2 
@@ -28,5 +27,9 @@ ${OBJECTS}:
 		${CPP} ${CPP_FLAGS} -fpic -o $@ ${@:%.o=%.cpp}
 
 install:
-		cp -f ${RESULT} ${LIBRARY_DIR}
-		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}
+		cp -f ${RESULT} ${LIBRARY_DIR}/
+		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}/
+
+uninstall:
+		rm ${LIBRARY_DIR}/${RESULT}
+		rm ${PHP_CONFIG_DIR}/${PHPINIFILE}

--- a/Examples/FunctionReturnValue/Makefile
+++ b/Examples/FunctionReturnValue/Makefile
@@ -2,10 +2,9 @@ CPP             = g++
 RM              = rm -f
 CPP_FLAGS       = -Wall -c -I. -O2 -std=c++11
 
-PREFIX			= /usr
-#Edit these lines to correspond with your own directories
+PHP_CONFIG      = $(shell which php-config)
 LIBRARY_DIR		= $(shell ${PHP_CONFIG} --extension-dir)
-PHP_CONFIG_DIR	= /etc/php5/cli/conf.d
+PHP_CONFIG_DIR	= $(shell ${PHP_CONFIG} --ini-dir)
 
 LD              = g++
 LD_FLAGS        = -Wall -shared -O2 
@@ -28,5 +27,9 @@ ${OBJECTS}:
 		${CPP} ${CPP_FLAGS} -fpic -o $@ ${@:%.o=%.cpp}
 
 install:
-		cp -f ${RESULT} ${LIBRARY_DIR}
-		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}
+		cp -f ${RESULT} ${LIBRARY_DIR}/
+		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}/
+
+uninstall:
+		rm ${LIBRARY_DIR}/${RESULT}
+		rm ${PHP_CONFIG_DIR}/${PHPINIFILE}

--- a/Examples/FunctionVoid/Makefile
+++ b/Examples/FunctionVoid/Makefile
@@ -2,10 +2,9 @@ CPP             = g++
 RM              = rm -f
 CPP_FLAGS       = -Wall -c -I. -O2 -std=c++11
 
-PREFIX			= /usr
-#Edit these lines to correspond with your own directories
+PHP_CONFIG      = $(shell which php-config)
 LIBRARY_DIR		= $(shell ${PHP_CONFIG} --extension-dir)
-PHP_CONFIG_DIR	= /etc/php5/cli/conf.d
+PHP_CONFIG_DIR	= $(shell ${PHP_CONFIG} --ini-dir)
 
 LD              = g++
 LD_FLAGS        = -Wall -shared -O2 
@@ -28,5 +27,9 @@ ${OBJECTS}:
 		${CPP} ${CPP_FLAGS} -fpic -o $@ ${@:%.o=%.cpp}
 
 install:
-		cp -f ${RESULT} ${LIBRARY_DIR}
-		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}
+		cp -f ${RESULT} ${LIBRARY_DIR}/
+		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}/
+
+uninstall:
+		rm ${LIBRARY_DIR}/${RESULT}
+		rm ${PHP_CONFIG_DIR}/${PHPINIFILE}

--- a/Examples/FunctionWithParameters/Makefile
+++ b/Examples/FunctionWithParameters/Makefile
@@ -2,10 +2,9 @@ CPP             = g++
 RM              = rm -f
 CPP_FLAGS       = -Wall -c -I. -O2 -std=c++11
 
-PREFIX			= /usr
-#Edit these lines to correspond with your own directories
+PHP_CONFIG      = $(shell which php-config)
 LIBRARY_DIR		= $(shell ${PHP_CONFIG} --extension-dir)
-PHP_CONFIG_DIR	= /etc/php5/cli/conf.d
+PHP_CONFIG_DIR	= $(shell ${PHP_CONFIG} --ini-dir)
 
 LD              = g++
 LD_FLAGS        = -Wall -shared -O2 
@@ -28,5 +27,9 @@ ${OBJECTS}:
 		${CPP} ${CPP_FLAGS} -fpic -o $@ ${@:%.o=%.cpp}
 
 install:
-		cp -f ${RESULT} ${LIBRARY_DIR}
-		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}
+		cp -f ${RESULT} ${LIBRARY_DIR}/
+		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}/
+
+uninstall:
+		rm ${LIBRARY_DIR}/${RESULT}
+		rm ${PHP_CONFIG_DIR}/${PHPINIFILE}

--- a/Examples/Globals/Makefile
+++ b/Examples/Globals/Makefile
@@ -2,10 +2,9 @@ CPP             = g++
 RM              = rm -f
 CPP_FLAGS       = -Wall -c -I. -O2 -std=c++11
 
-PREFIX			= /usr
-PHP_CONFIG      = php-config
+PHP_CONFIG      = $(shell which php-config)
 LIBRARY_DIR		= $(shell ${PHP_CONFIG} --extension-dir)
-PHP_CONFIG_DIR	= /etc/php5/cli/conf.d
+PHP_CONFIG_DIR	= $(shell ${PHP_CONFIG} --ini-dir)
 
 LD              = g++
 LD_FLAGS        = -Wall -shared -O2 
@@ -28,5 +27,9 @@ ${OBJECTS}:
 		${CPP} ${CPP_FLAGS} -fpic -o $@ ${@:%.o=%.cpp}
 
 install:
-		cp -f ${RESULT} ${LIBRARY_DIR}
-		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}
+		cp -f ${RESULT} ${LIBRARY_DIR}/
+		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}/
+
+uninstall:
+		rm ${LIBRARY_DIR}/${RESULT}
+		rm ${PHP_CONFIG_DIR}/${PHPINIFILE}

--- a/Examples/ReturnObject/Makefile
+++ b/Examples/ReturnObject/Makefile
@@ -29,7 +29,7 @@ NAME				=	returnobject
 #	one for each extension. Use this variable to specify this directory.
 #
 
-INI_DIR				=	/etc/php5/mods-available/
+INI_DIR				=	$(shell php-config --ini-dir)
 
 
 #

--- a/Examples/simple/Makefile
+++ b/Examples/simple/Makefile
@@ -2,12 +2,9 @@ CPP             = g++
 RM              = rm -f
 CPP_FLAGS       = -Wall -c -I. -I/home/work/include/ -O2 -std=c++11
 
-PREFIX			= /home/work/
-
-#Edit these lines to correspond with your own directories
-LIBRARY_DIR		= ${PREFIX}/local/php/lib/php/extensions/no-debug-non-zts-20090626/
-
-PHP_CONFIG_DIR	= /home/work/local/php/lib/
+PHP_CONFIG      = $(shell which php-config)
+LIBRARY_DIR		= $(shell ${PHP_CONFIG} --extension-dir)
+PHP_CONFIG_DIR	= $(shell ${PHP_CONFIG} --ini-dir)
 
 LD              = g++
 LD_FLAGS        = -Wall -Wl,-rpath,/home/work/lib -shared -O2 -L/home/work/lib
@@ -30,5 +27,9 @@ ${OBJECTS}:
 		${CPP} ${CPP_FLAGS} -fpic -o $@ ${@:%.o=%.cpp}
 
 install:
-		cp -f ${RESULT} ${LIBRARY_DIR}
-		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}
+		cp -f ${RESULT} ${LIBRARY_DIR}/
+		cp -f ${PHPINIFILE}	${PHP_CONFIG_DIR}/
+
+uninstall:
+		rm ${LIBRARY_DIR}/${RESULT}
+		rm ${PHP_CONFIG_DIR}/${PHPINIFILE}


### PR DESCRIPTION
The Makefiles in the Examples directory hardcode the location of the php ini directory. This changes that to dynamically use "php-config --ini-dir" to configure it. It also adds an uninstall target.