### PR TITLE
PHP-CPP: PHP 8.4 support

### DIFF
--- a/zend/callable.cpp
+++ b/zend/callable.cpp
@@ -124,6 +124,10 @@ void Callable::initialize(zend_function_entry *entry, const char *classname, int
     entry->arg_info = _argv.get();
     entry->num_args = _argc;
     entry->flags = flags;
+#if PHP_VERSION_ID >= 80400
+    entry->frameless_function_infos = nullptr;
+    entry->doc_comment = nullptr;
+#endif
 
     // we should fill the first argument as well
     initialize((zend_internal_function_info*)_argv.get(), classname);

--- a/zend/classimpl.cpp
+++ b/zend/classimpl.cpp
@@ -56,14 +56,22 @@ static ClassImpl *self(zend_class_entry *entry)
      *  the string, in case PHP tries to read it) and after that the pointer
      *  and we leave the doc_comment_len at 0.
      */
+#if PHP_VERSION_ID < 80400
     while (entry->parent && (entry->info.user.doc_comment == nullptr || ZSTR_LEN(entry->info.user.doc_comment) > 0))
+#else
+    while (entry->parent && (entry->doc_comment == nullptr || ZSTR_LEN(entry->doc_comment) > 0))
+#endif
     {
         // we did not create this class entry, but luckily we have a parent
         entry = entry->parent;
     }
 
     // retrieve the comment (it has a pointer hidden in it to the ClassBase object)
+#if PHP_VERSION_ID < 80400
     const char *comment = ZSTR_VAL(entry->info.user.doc_comment);
+#else
+    const char *comment = ZSTR_VAL(entry->doc_comment);
+#endif
 
     // the first byte of the comment is an empty string (null character), but
     // the next bytes contain a pointer to the ClassBase class
@@ -1604,7 +1612,11 @@ zend_class_entry *ClassImpl::initialize(ClassBase *base, const std::string &pref
     std::memcpy(ZSTR_VAL(_self) + 1, &impl, sizeof(impl));
 
     // install the doc_comment
+#if PHP_VERSION_ID < 80400
     _entry->info.user.doc_comment = _self;
+#else
+    _entry->doc_comment = _self;
+#endif
 
     // declare all member variables
     for (auto &member : _members) member->initialize(_entry);

--- a/zend/classimpl.cpp
+++ b/zend/classimpl.cpp
@@ -23,8 +23,11 @@ ClassImpl::~ClassImpl()
     // destruct the entries
     delete[] _entries;
 
+    // PHP 8.4 frees doc_comment if not null, so skip.
+#if PHP_VERSION_ID < 80400
     // free the stored pointer
     if (_self) zend_string_release(_self);
+#endif
 }
 
 /**

--- a/zend/iteratorimpl.cpp
+++ b/zend/iteratorimpl.cpp
@@ -68,7 +68,11 @@ void IteratorImpl::destructor(zend_object_iterator *iter)
  *  @param  iter
  *  @return int
  */
+#if PHP_VERSION_ID < 80400
 int IteratorImpl::valid(zend_object_iterator *iter)
+#else
+zend_result IteratorImpl::valid(zend_object_iterator *iter)
+#endif
 {
     // check if valid
     return self(iter)->valid() ? SUCCESS : FAILURE;

--- a/zend/iteratorimpl.h
+++ b/zend/iteratorimpl.h
@@ -121,7 +121,11 @@ private:
      *  @param  iter
      *  @return int
      */
+#if PHP_VERSION_ID < 80400
     static int valid(zend_object_iterator *iter);
+#else
+    static zend_result valid(zend_object_iterator *iter);
+#endif
 
     /**
      *  Fetch the current item

--- a/zend/module.h
+++ b/zend/module.h
@@ -179,17 +179,23 @@ public:
         // this is not possible if the module is invalid in the first place
         if (!valid()) return false;
         
+#if PHP_VERSION_ID < 80400
         // the Zend engine sets a number of properties in the entry class, we do that here too
         // note that it would be better to call zend_next_free_module() to find the next module
         // number, but some users complain that this function is not always available
         _entry->type = MODULE_TEMPORARY;
         _entry->module_number = zend_hash_num_elements(&module_registry) + 1;
+#endif
         _entry->handle = _handle;
         
         // @todo does loading an extension even work in a multi-threading setup?
         
         // register the module, this apparently returns a copied entry pointer
+#if PHP_VERSION_ID < 80400
         auto *entry = zend_register_module_ex(_entry);
+#else
+        auto *entry = zend_register_module_ex(_entry, MODULE_TEMPORARY);
+#endif
 
         // forget the entry, so that a new call to start() will fail too
         _entry = nullptr;


### PR DESCRIPTION
**module.h** - function signature changed
https://github.com/php/php-src/blob/91f0b3bc0416539f64c44d453100274ccae942b3/Zend/zend_API.c#L2582

**classimpl.cpp** - `doc_comment` moved out of `info.user`
https://github.com/php/php-src/blob/91f0b3bc0416539f64c44d453100274ccae942b3/Zend/zend.h#L224

**iteratorimpl.(cpp|h)** - valid now returns `zend_result`
https://github.com/php/php-src/blob/91f0b3bc0416539f64c44d453100274ccae942b3/Zend/zend_iterators.h#L39

PHP Docs for 8.4 internals: https://github.com/php/php-src/blob/php-8.4.1/UPGRADING.INTERNALS

Props @vnsavage for fixing the `doc_comment` double-free.
