### PR TITLE
Fix PHP serialization for classes implementing serializable interface

### DIFF
--- a/include/base.h
+++ b/include/base.h
@@ -267,7 +267,7 @@ public:
      *  is handled by the user-space implementation of Serializable::serialize()).
      *  @return Php::Value
      */
-    Php::Value __serialize();
+    Php::Value serialize();
 
     /**
      *  Method that is called when an explicit call to $object->unserialize() is made
@@ -275,7 +275,7 @@ public:
      *  is handled by the user-space implementation of Serializable::unserialize()).
      *  @param params       The passed parameters
      */
-    void __unserialize(Php::Parameters &params);
+    void unserialize(Php::Parameters &params);
 
     /**
      *  Method that is called when an explicit call to $object->count() is made

--- a/zend/base.cpp
+++ b/zend/base.cpp
@@ -223,7 +223,7 @@ int Base::__compare(const Base &that) const
  *  is handled by the user-space implementation of Serializable::serialize()).
  *  @return Php::Value
  */
-Php::Value Base::__serialize()
+Php::Value Base::serialize()
 {
     // 'this' refers to a Php::Base class, but we expect that is also implements the Serializable
     // interface (otherwise we would never have registered the __serialize function as a callback)
@@ -242,7 +242,7 @@ Php::Value Base::__serialize()
  *  is handled by the user-space implementation of Serializable::unserialize()).
  *  @param params       The passed parameters
  */
-void Base::__unserialize(Php::Parameters &params)
+void Base::unserialize(Php::Parameters &params)
 {
     // 'this' refers to a Php::Base class, but we expect that is also implements the Serializable
     // interface (otherwise we would never have registered the __serialize function as a callback)

--- a/zend/classimpl.cpp
+++ b/zend/classimpl.cpp
@@ -1464,8 +1464,8 @@ const struct _zend_function_entry *ClassImpl::entries()
     {
         // the method object need to stay in scope for the lifetime of the script (because the register a pointer
         // to an internal string buffer) -- so we create them as static variables
-        static Method serialize("serialize", &Base::__serialize, 0, {});
-        static Method unserialize("unserialize", &Base::__unserialize, 0, { ByVal("input", Type::Undefined, true) });
+        static Method serialize("serialize", &Base::serialize, 0, {});
+        static Method unserialize("unserialize", &Base::unserialize, 0, { ByVal("input", Type::Undefined, true) });
 
         // register the serialize and unserialize method in case this was not yet done in PHP user space
         if (!hasMethod("serialize")) serialize.initialize(&_entries[i++], _name);
@@ -1542,14 +1542,6 @@ zend_class_entry *ClassImpl::initialize(ClassBase *base, const std::string &pref
         // from 7.3 and up, we may have to allocate it ourself
         //entry.iterator_funcs_ptr = calloc(1, sizeof(zend_class_iterator_funcs));
 #endif
-    }
-
-    // for serializable classes, we install callbacks for serializing and unserializing
-    if (_base->serializable())
-    {
-        // add handlers to serialize and unserialize
-        entry.serialize = &ClassImpl::serialize;
-        entry.unserialize = &ClassImpl::unserialize;
     }
 
     // do we have a base class?


### PR DESCRIPTION
## Problem

When `PxCDMWebTrackerSessionIdentifier` was serialized, PHP's `serialize()` function used serialization handlers instead of the PHP class's `serialize()` method, producing incompatible data:

```
C:32:"PxCDMWebTrackerSessionIdentifier":39:{aeebaqaabqqcabaqeeaaacadaqbidvunnkeucjq}
```

During deserialization, this caused:
```
TypeError: Argument 1 passed to PxCDMWebTrackerSessionIdentifier::fromArray() 
must be of the type array, bool given
```

When PHP's `serialize()` was called, it found and used handlers (`ClassImpl::serialize` and `ClassImpl::unserialize`),  bypassing the PHP method table. These handlers directly called `Serializable::serialize()` and produced binary data that was incompatible with what the PHP class's `unserialize()` method expected to receive.

## Solution

In this project, we remove the use of serialization handlers from classimpl.cpp and changed the PHP method names. By removing the use of these handlers and updating the method names, PHP's `serialize()` now correctly uses the methods registered in the PHP function table. These methods call `Base::serialize` which bridges to the C++ `Serializable` interface, allowing the PHP class's `serialize()` method to execute and produce the expected serialized format that its `unserialize()` method can correctly parse.