### PR TITLE
Guard __invoke scope assignment for PHP 7.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ INSTALL_LIB				=	${INSTALL_PREFIX}/lib
 #
 
 SONAME					=	2.4
-VERSION					=	2.4.15
+VERSION					=	2.4.16
 
 
 #

--- a/zend/classimpl.cpp
+++ b/zend/classimpl.cpp
@@ -340,7 +340,11 @@ zend_result ClassImpl::getClosure(ZEND_OBJECT_OR_ZVAL object, zend_class_entry *
     ZSTR_LEN(zend_empty_string) = 0;
 #endif
     function->function_name     = zend_string_init("__invoke", sizeof("__invoke") - 1, 0);  // should not be null, as this is free'ed by zend when doing exception handling
+#if PHP_VERSION_ID < 80000
+    function->scope             = Z_OBJCE_P(object);
+#else
     function->scope             = object->ce;
+#endif
     function->prototype         = nullptr;
     function->num_args          = 0;
     function->required_num_args = 0;


### PR DESCRIPTION
In this project, we wrap the function->scope assignment in ClassImpl::getClosure() in a PHP_VERSION_ID conditional, because it uses object->ce, which only exists when ZEND_OBJECT_OR_ZVAL resolves to a zend_object* on PHP 8. On PHP 7.4 the same parameter is a zval*, so the code fails to compile there ('zval' has no member named 'ce'), which broke the build on Ubuntu focal.